### PR TITLE
docs: fix RedisVectorDatabase import in redis sample app docs

### DIFF
--- a/docs/run-in-production/vdbs/redis/amazon_reviews_app_with_redis.py
+++ b/docs/run-in-production/vdbs/redis/amazon_reviews_app_with_redis.py
@@ -16,7 +16,7 @@ from superlinked.framework.dsl.source.data_loader_source import DataFormat, Data
 from superlinked.framework.dsl.source.rest_source import RestSource
 from superlinked.framework.dsl.space.number_space import NumberSpace
 from superlinked.framework.dsl.space.text_similarity_space import TextSimilaritySpace
-from superlinked.framework.dsl.storage.redis_db_vector_database import RedisVectorDatabase
+from superlinked.framework.dsl.storage.redis_vector_database import RedisVectorDatabase
 
 openai_config = OpenAIClientConfig(api_key="YOUR_OPENAI_API_KEY", model="gpt-4o")
 

--- a/docs/run-in-production/vdbs/redis/app_with_redis.py
+++ b/docs/run-in-production/vdbs/redis/app_with_redis.py
@@ -12,7 +12,7 @@ from superlinked.framework.dsl.query.query import Query
 from superlinked.framework.dsl.registry.superlinked_registry import SuperlinkedRegistry
 from superlinked.framework.dsl.source.rest_source import RestSource
 from superlinked.framework.dsl.space.text_similarity_space import TextSimilaritySpace
-from superlinked.framework.dsl.storage.redis_db_vector_database import RedisVectorDatabase
+from superlinked.framework.dsl.storage.redis_vector_database import RedisVectorDatabase
 
 @schema
 class CarSchema:


### PR DESCRIPTION
Import of `RedisVectorDatabase` was pointing to a nonexistent file so the code sample in the doc was not working, (`redis_vector_database` is the filename, vs `redis_db_vector_database` in the docs)