### PR TITLE
[docs] add TopK into docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Superlinked stores *your vectors* in *your vector database*, with deep integrati
 - [Redis](https://docs.superlinked.com/run-in-production/index-1/redis)
 - [MongoDB](https://docs.superlinked.com/run-in-production/index-1/mongodb)
 - [Qdrant](https://docs.superlinked.com/run-in-production/index-1/qdrant)
+- [TopK](https://docs.superlinked.com/run-in-production/index-1/topk)
 - [Which one should we support next?](https://github.com/superlinked/superlinked/discussions/41)
 
 Curious about vector database pros & cons in general? Our community [compared 44 Vector Databases on 30+ features](https://superlinked.com/vector-db-comparison/).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
   * [Redis](run-in-production/vdbs/redis.md)
   * [Mongo DB](run-in-production/vdbs/mongodb.md)
   * [Qdrant](run-in-production/vdbs/qdrant.md)
+  * [TopK](run-in-production/vdbs/topk.md)
 
 
 ## Concepts

--- a/docs/getting-started/why-superlinked.md
+++ b/docs/getting-started/why-superlinked.md
@@ -124,6 +124,7 @@ sl.RestExecutor(
     # vector_database = sl.MongoDBVectorDatabase(...),
     # vector_database = sl.RedisVectorDatabase(...),
     # vector_database = sl.QdrantVectorDatabase(...),
+    # vector_database = sl.TopKVectorDatabase(...),
 )
 
 # SparkExecutor()   <-- Coming soon in Superlinked Cloud

--- a/docs/recipes/hotel-search.md
+++ b/docs/recipes/hotel-search.md
@@ -208,7 +208,7 @@ Our github contains many helpful notebooks that show how to configure superlinke
 This file sets the following components:
 
 - vector database: in current application we are using Redis.
-  We also support [MongoDB and Qdrant](https://docs.superlinked.com/run-in-production/index-1).
+  We also support [MongoDB, Qdrant and TopK](https://docs.superlinked.com/run-in-production/index-1).
 - data loader: our data is ingested from gcp bucket
 - REST API: our app will provide endpoints for ingestion (bulk and one-by-one) and for querying. More information is in [our docs](https://docs.superlinked.com/run-in-production/index/interacting-with-app-via-api).
 

--- a/docs/run-in-production/overview.md
+++ b/docs/run-in-production/overview.md
@@ -18,5 +18,6 @@ We have started partnering with vector database providers to allow you to use Su
 - [Redis](vdbs/redis.md)
 - [MongoDB](vdbs/mongodb.md)
 - [Qdrant](vdbs/qdrant.md)
+- [TopK](vdbs/topk.md)
 
 Missing your favorite VDB? [Tell us which vector database we should support next!](https://github.com/superlinked/superlinked/discussions/41)

--- a/docs/run-in-production/vdbs/index.md
+++ b/docs/run-in-production/vdbs/index.md
@@ -10,5 +10,6 @@ This document will list and point to the detailed documentation of the supported
 - [Redis](redis.md)
 - [MongoDB](mongodb.md)
 - [Qdrant](qdrant.md)
+- [TopK](topk.md)
 
 Missing your favorite one? [Let us know in github discussions](https://github.com/superlinked/superlinked/discussions/41)

--- a/docs/run-in-production/vdbs/topk.md
+++ b/docs/run-in-production/vdbs/topk.md
@@ -1,0 +1,55 @@
+# TopK
+
+This document provides clear steps on how to use and integrate TopK with Superlinked.
+
+## Configuring your existing TopK account
+
+To use Superlinked with TopK, you'll need to create a TopK account and set up a project. For detailed steps on setting up your TopK account, refer to the [Set up your TopK Account](#set-up-your-topk-account) section below.
+
+Once your TopK project is set up, you'll need to obtain your API key and region information to configure the authentication settings as described below.
+
+## Modifications in your configuration
+
+To integrate TopK, you need to add the `TopKVectorDatabase` class and include it in the executor. Here’s how you can do it:
+
+````python
+from superlinked import framework as sl
+
+vector_database = sl.TopKVectorDatabase(
+    "<your_api_key>", # (Mandatory) This is your TopK API key
+    "<your_region>", # (Mandatory) This is your TopK region
+    default_query_limit=10, # (Optional) This parameter specifies the maximum number of query results returned. If not set, it defaults to 10.
+)
+
+Once you have configured the vector database just simply pass it to the executor.
+
+```python
+...
+executor = sl.RestExecutor(
+    sources=[source],
+    indices=[index],
+    queries=[sl.RestQuery(sl.RestDescriptor("query"), query)],
+    vector_database=vector_database,
+)
+...
+````
+
+## Set up your TopK Account
+
+To set up your TopK account and obtain the necessary credentials for Superlinked integration, follow these steps:
+
+1. **Go to the TopK Console**
+   Navigate to [TopK Console](https://console.topk.io) and create an account or sign in to your existing account.
+
+2. **Create or Select a Project**
+   TopK follows an `Organization > Project > Collection` hierarchical structure. Create a new project or use an existing one within your organization.
+
+3. **Generate an API Key**
+   Follow the TopK [documentation](https://docs.topk.io/installation#api-key) to generate a API key for your project.
+
+4. **Note your Region**
+   TopK is region-specific. Refer to the TopK documentation for available regions and ensure you use the correct region for your project. Attempting to access collections or documents outside the specified region will result in a region mismatch error.
+
+## Example app with TopK
+
+You can find an example that utilizes TopK [here](https://github.com/superlinked/superlinked/blob/main/docs/run-in-production/vdbs/topk/app_with_topk.py).

--- a/docs/run-in-production/vdbs/topk.md
+++ b/docs/run-in-production/vdbs/topk.md
@@ -16,8 +16,8 @@ To integrate TopK, you need to add the `TopKVectorDatabase` class and include it
 from superlinked import framework as sl
 
 vector_database = sl.TopKVectorDatabase(
-    "<your_api_key>", # (Mandatory) This is your TopK API key
-    "<your_region>", # (Mandatory) This is your TopK region
+    api_key="<your_api_key>", # (Mandatory) This is your TopK API key
+    region="<your_region>", # (Mandatory) This is your TopK region
     default_query_limit=10, # (Optional) This parameter specifies the maximum number of query results returned. If not set, it defaults to 10.
 )
 

--- a/docs/run-in-production/vdbs/topk/amazon_reviews_app_with_topk.py
+++ b/docs/run-in-production/vdbs/topk/amazon_reviews_app_with_topk.py
@@ -1,0 +1,68 @@
+from superlinked import framework as sl
+
+openai_config = sl.OpenAIClientConfig(api_key="YOUR_OPENAI_API_KEY", model="gpt-4o")
+
+
+@sl.schema
+class Review:
+    id: sl.IdField
+    review_text: sl.String
+    rating: sl.Integer
+    full_review_as_text: sl.String
+
+
+review = Review()
+
+review_text_space = sl.TextSimilaritySpace(text=review.review_text, model="all-MiniLM-L6-v2")
+rating_maximizer_space = sl.NumberSpace(number=review.rating, min_value=1, max_value=5, mode=sl.Mode.MAXIMUM)
+full_review_as_text_space = sl.TextSimilaritySpace(text=review.full_review_as_text, model="all-MiniLM-L6-v2")
+
+naive_index = sl.Index([full_review_as_text_space])
+advanced_index = sl.Index([review_text_space, rating_maximizer_space])
+
+naive_query = (
+    sl.Query(
+        naive_index,
+        weights={full_review_as_text_space: sl.Param("full_review_as_text_weight")},
+    )
+    .find(review)
+    .similar(full_review_as_text_space.text, sl.Param("query_text"))
+    .select_all()
+    .limit(sl.Param("limit"))
+    .with_natural_query(sl.Param("natural_query"), openai_config)
+)
+superlinked_query = (
+    sl.Query(
+        advanced_index,
+        weights={
+            review_text_space: sl.Param("review_text_weight"),
+            rating_maximizer_space: sl.Param("rating_maximizer_weight"),
+        },
+    )
+    .find(review)
+    .similar(review_text_space.text, sl.Param("query_text"))
+    .select_all()
+    .limit(sl.Param("limit"))
+    .with_natural_query(sl.Param("natural_query"), openai_config)
+)
+
+
+review_source: sl.RestSource = sl.RestSource(review)
+review_data_loader = sl.DataLoaderConfig(
+    "https://storage.googleapis.com/superlinked-sample-datasets/amazon_dataset_ext_1000.jsonl",
+    sl.DataFormat.JSON,
+    pandas_read_kwargs={"lines": True, "chunksize": 100},
+)
+review_loader_source: sl.DataLoaderSource = sl.DataLoaderSource(review, review_data_loader)
+topk_vector_database = sl.TopKVectorDatabase(api_key="...", region="...")
+executor = sl.RestExecutor(
+    sources=[review_source, review_loader_source],
+    indices=[naive_index, advanced_index],
+    queries=[
+        sl.RestQuery(sl.RestDescriptor("naive_query"), naive_query),
+        sl.RestQuery(sl.RestDescriptor("superlinked_query"), superlinked_query),
+    ],
+    vector_database=topk_vector_database,
+)
+
+sl.SuperlinkedRegistry.register(executor)

--- a/docs/run-in-production/vdbs/topk/app_with_topk.py
+++ b/docs/run-in-production/vdbs/topk/app_with_topk.py
@@ -1,0 +1,38 @@
+from superlinked import framework as sl
+
+
+@sl.schema
+class CarSchema:
+    id: sl.IdField
+    make: sl.String
+    model: sl.String
+
+
+car_schema = CarSchema()
+
+car_make_text_space = sl.TextSimilaritySpace(text=car_schema.make, model="all-MiniLM-L6-v2")
+car_model_text_space = sl.TextSimilaritySpace(text=car_schema.model, model="all-MiniLM-L6-v2")
+
+index = sl.Index([car_make_text_space, car_model_text_space])
+
+query = (
+    sl.Query(index)
+    .find(car_schema)
+    .similar(car_make_text_space.text, sl.Param("make"))
+    .similar(car_model_text_space.text, sl.Param("model"))
+    .select_all()
+    .limit(sl.Param("limit"))
+)
+
+car_source: sl.RestSource = sl.RestSource(car_schema)
+
+topk_vector_database = sl.TopKVectorDatabase(api_key="...", region="...")
+
+executor = sl.RestExecutor(
+    sources=[car_source],
+    indices=[index],
+    queries=[sl.RestQuery(sl.RestDescriptor("query"), query)],
+    vector_database=topk_vector_database,
+)
+
+sl.SuperlinkedRegistry.register(executor)


### PR DESCRIPTION
TopK adapter was added in [this commit](https://github.com/superlinked/superlinked/commit/b1ae0ba92ab92c404343b6c2fa907bc9f5e2c5c2). This PR adds TopK docs into [Supported Vector Databases](https://docs.superlinked.com/run-in-production/index-1).