### PR TITLE
fix: use Docker instead of pip install sie-server in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,9 @@ SIE is an open-source inference engine that serves embeddings, reranking, and en
 
 ## Quickstart
 
-Or try it in your browser, no install needed: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/superlinked/sie/blob/main/notebooks/quickstart.ipynb)
+Or try it in your browser: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/superlinked/sie/blob/main/notebooks/quickstart.ipynb)
 
 **1. Start the server**
-
-```bash
-pip install sie-server
-sie-server serve            # auto-detects CUDA / Apple Silicon / CPU
-```
-
-Or with Docker:
 
 ```bash
 docker run -p 8080:8080 ghcr.io/superlinked/sie-server:latest-cpu-default                # CPU

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -1,110 +1,114 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "# SIE Quickstart\n\nThree functions - `encode`, `score`, `extract` - running on a free Colab GPU.\n\nThis notebook installs the SIE server, starts it in the background, and walks through the full API."
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# SIE Quickstart\n",
+        "\n",
+        "Three functions - `encode`, `score`, `extract` - cover the full API.\n",
+        "\n",
+        "## 1. Start the server\n",
+        "\n",
+        "Run the SIE server with Docker before using this notebook:\n",
+        "\n",
+        "```bash\n",
+        "# CPU\n",
+        "docker run -p 8080:8080 ghcr.io/superlinked/sie-server:latest-cpu-default\n",
+        "\n",
+        "# GPU (NVIDIA)\n",
+        "docker run --gpus all -p 8080:8080 ghcr.io/superlinked/sie-server:latest-cuda12-default\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install -q sie-sdk"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## 2. Encode\n\nGenerate dense embeddings with a 400M-parameter model. The model downloads on first use (~1-2 min), then subsequent calls are fast."
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from sie_sdk import SIEClient\n",
+        "from sie_sdk.types import Item\n",
+        "\n",
+        "client = SIEClient(\"http://localhost:8080\")\n",
+        "\n",
+        "result = client.encode(\"NovaSearch/stella_en_400M_v5\", Item(text=\"Hello world\"))\n",
+        "print(f\"Shape: {result['dense'].shape}\")   # (1024,)\n",
+        "print(f\"First 5 values: {result['dense'][:5]}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Score\n",
+        "\n",
+        "Rerank documents by relevance using a cross-encoder."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "scores = client.score(\n    \"BAAI/bge-reranker-v2-m3\",\n    Item(text=\"What is machine learning?\"),\n    [Item(text=\"ML learns from data.\"), Item(text=\"The weather is sunny.\")]\n)\n\nfor s in scores[\"scores\"]:\n    print(f\"  rank {s['rank']}: {s['score']:.3f} - {s['item_id']}\")"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## 4. Extract\n\nZero-shot named entity recognition - no training data needed."
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "result = client.extract(\n",
+        "    \"urchade/gliner_multi-v2.1\",\n",
+        "    Item(text=\"Tim Cook is the CEO of Apple.\"),\n",
+        "    labels=[\"person\", \"organization\"]\n",
+        ")\n",
+        "\n",
+        "for e in result[\"entities\"]:\n",
+        "    print(f\"  {e['label']}: {e['text']} ({e['score']:.2f})\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Next steps\n\n- [API reference](https://sie.dev/docs/reference/sdk) - full SDK documentation\n- [All models](https://sie.dev/docs/reference/models) - 85+ supported models\n- [Deployment guide](https://sie.dev/docs/deployment/docker) - run in production with Docker or Kubernetes\n- [GitHub](https://github.com/superlinked/sie) - star the repo if this was useful"
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12.0"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 1. Install and start the server\n\nColab already has PyTorch, so this only installs the incremental dependencies (~1-2 min).\n\n> **Note:** SIE requires Python 3.12. If your Colab runtime uses an older version, go to Runtime > Change runtime type and select Python 3.12."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install -q sie-server sie-sdk"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "import subprocess, time, urllib.request\n\n# Start the server in the background\nproc = subprocess.Popen(\n    [\"sie-server\", \"serve\", \"--host\", \"0.0.0.0\", \"--port\", \"8080\"],\n    stdout=open(\"/tmp/sie-server.log\", \"w\"),\n    stderr=subprocess.STDOUT,\n)\n\n# Wait for the server to be ready\nfor i in range(60):\n    try:\n        urllib.request.urlopen(\"http://localhost:8080/healthz\")\n        print(f\"Server ready (took ~{i}s)\")\n        break\n    except Exception:\n        time.sleep(1)\nelse:\n    print(\"Server did not start - check /tmp/sie-server.log\")"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 2. Encode\n\nGenerate dense embeddings with a 400M-parameter model. The model downloads on first use (~1-2 min), then subsequent calls are fast."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sie_sdk import SIEClient\n",
-    "from sie_sdk.types import Item\n",
-    "\n",
-    "client = SIEClient(\"http://localhost:8080\")\n",
-    "\n",
-    "result = client.encode(\"NovaSearch/stella_en_400M_v5\", Item(text=\"Hello world\"))\n",
-    "print(f\"Shape: {result['dense'].shape}\")   # (1024,)\n",
-    "print(f\"First 5 values: {result['dense'][:5]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3. Score\n",
-    "\n",
-    "Rerank documents by relevance using a cross-encoder."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "scores = client.score(\n    \"BAAI/bge-reranker-v2-m3\",\n    Item(text=\"What is machine learning?\"),\n    [Item(text=\"ML learns from data.\"), Item(text=\"The weather is sunny.\")]\n)\n\nfor s in scores[\"scores\"]:\n    print(f\"  rank {s['rank']}: {s['score']:.3f} - {s['item_id']}\")"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 4. Extract\n\nZero-shot named entity recognition - no training data needed."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result = client.extract(\n",
-    "    \"urchade/gliner_multi-v2.1\",\n",
-    "    Item(text=\"Tim Cook is the CEO of Apple.\"),\n",
-    "    labels=[\"person\", \"organization\"]\n",
-    ")\n",
-    "\n",
-    "for e in result[\"entities\"]:\n",
-    "    print(f\"  {e['label']}: {e['text']} ({e['score']:.2f})\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Next steps\n\n- [API reference](https://sie.dev/docs/reference/sdk) - full SDK documentation\n- [All models](https://sie.dev/docs/reference/models) - 85+ supported models\n- [Deployment guide](https://sie.dev/docs/deployment/docker) - run in production with Docker or Kubernetes\n- [GitHub](https://github.com/superlinked/sie) - star the repo if this was useful"
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "gpuType": "T4",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.12.0"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- Remove `pip install sie-server` / `sie-server serve` from README quickstart — sie-server is not published on PyPI
- Update Colab notebook to use Docker for the server instead of `pip install sie-server` + subprocess start
- Docker is the actual distribution method for the server; SDK (`pip install sie-sdk`) remains unchanged

## Test plan
- [X] Verify README renders correctly on GitHub
- [X] Open Colab notebook link from README badge and confirm it loads