### PR TITLE
Retitle examples for SEO and add intro to retrieval-ablation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,12 +11,12 @@ service keys.
 
 | Example | Best for | SIE primitives | Setup | Status |
 |---|---|---|---|---|
-| [E-Commerce Product Search](./ecommerce-product-search) | Showing the fastest local product-search path with extraction, embeddings, and reranking | `extract`, `encode`, `score` | Local SIE Docker image, Python or TypeScript app | Runnable |
-| [Retrieval Ablation](./retrieval-ablation) | Demonstrating eval-driven model selection for production RAG retrieval | `encode`, `score` | SIE endpoint, Turbopuffer key, optional SIE API key for auth-enabled clusters | Runnable benchmark |
-| [Hugging Face MTEB Semantic Search](./sie-hugging-face-mteb-semantic-search) | Building a semantic-search app over model metadata and benchmark results | `encode`, `score` | Backend seed script plus Vite frontend; falls back without a live SIE endpoint | Runnable |
-| [Regulatory RAG](./regulatory-rag) | Hosting custom adapters and LoRA profiles in SIE | `encode`, `score`, `extract` | Custom SIE Docker image, GPU recommended | Advanced runnable example |
-| [Wine Recommender](./wine-recommender) | Combining recommendation reranking with OCR-style extraction in a UI | `encode`, `score`, `extract` | Docker Compose app plus local SIE endpoint; API key optional for unauthenticated SIE | Runnable demo |
-| [Taxonomy Classification](./taxonomy-classification) | Evaluating text, image, NLI, and reranking approaches for hierarchical product taxonomy classification | `extract`, `encode`, `score` | SIE endpoint, Shopify dataset prep via `uv run` scripts, standalone `uv` project | Runnable evaluation example |
+| [Self-hosted product search in 5 min](./ecommerce-product-search) | Showing the fastest local product-search path with extraction, embeddings, and reranking | `extract`, `encode`, `score` | Local SIE Docker image, Python or TypeScript app | Runnable |
+| [Find the best retrieval strategy for your RAG](./retrieval-ablation) | Picking a production RAG retrieval pipeline by evals on real financial documents | `encode`, `score` | SIE endpoint, Turbopuffer key, optional SIE API key for auth-enabled clusters | Runnable benchmark |
+| [Find SOTA embedding models by MTEB task](./sie-hugging-face-mteb-semantic-search) | Searching ~14K HF embedding models ranked by task-specific MTEB scores | `encode`, `score` | Backend seed script plus Vite frontend; falls back without a live SIE endpoint | Runnable |
+| [Private fine-tuned compliance RAG](./regulatory-rag) | Hot-loading a domain LoRA encoder and a custom token-pruning adapter on SIE | `encode`, `score`, `extract` | Custom SIE Docker image, GPU recommended | Advanced runnable example |
+| [Build a multimodal wine recommender with OCR](./wine-recommender) | Combining preference-based retrieval with OCR-driven label detection in one UI | `encode`, `score`, `extract` | Docker Compose app plus local SIE endpoint; API key optional for unauthenticated SIE | Runnable demo |
+| [Build a multi-modal product classifier with embeddings](./taxonomy-classification) | Evaluating text, image, NLI, and reranking approaches for hierarchical product taxonomy classification | `extract`, `encode`, `score` | SIE endpoint, Shopify dataset prep via `uv run` scripts, standalone `uv` project | Runnable evaluation example |
 
 For docs publishing, lead with the quickest runnable demos, then use the
 benchmark and evaluation examples for deeper technical users.

--- a/examples/ecommerce-product-search/README.md
+++ b/examples/ecommerce-product-search/README.md
@@ -1,4 +1,4 @@
-# E-Commerce Product Search
+# Self-hosted product search in 5 min
 
 <p align="center">
   <img src="./assets/hero.png" alt="E-Commerce Product Search: extract, encode, score on a single SIE cluster" width="100%" />

--- a/examples/regulatory-rag/README.md
+++ b/examples/regulatory-rag/README.md
@@ -1,4 +1,4 @@
-# Regulatory RAG: Custom Models on SIE
+# Private fine-tuned compliance RAG
 
 The "advanced hosting" example. Shows how to run a real production
 RAG stack on SIE with **two things you won't find in a stock

--- a/examples/regulatory-rag/README.md
+++ b/examples/regulatory-rag/README.md
@@ -13,11 +13,11 @@ forward pass. Everything needed to host the advanced stuff lives in
 
 Detail per stage:
 
-- **Encode** — `ModernBERT-base` with the `us-regulatory` profile, which hot-loads the `sugiv/modernbert-us-stablecoin-encoder` LoRA weights at request time. Produces a 768-dim domain-adapted embedding.
-- **Dense retrieval** — in-memory cosine similarity over the corpus, top-5 kept.
-- **Score / Rerank** — `sugiv/stablebridge-pruner-highlighter` cross-encoder, keeps top-3.
-- **Extract / Prune** — same Stablebridge model, second primitive. Returns token-level keep/drop probabilities aggregated into `highlight` / `kept` / `pruned` spans.
-- **LLM context** — the surviving `highlight` and `kept` spans become the compressed context passed downstream. Averages 74% compression vs. the raw reranked passages.
+- **Encode**: `ModernBERT-base` with the `us-regulatory` profile, which hot-loads the `sugiv/modernbert-us-stablecoin-encoder` LoRA weights at request time. Produces a 768-dim domain-adapted embedding.
+- **Dense retrieval**: in-memory cosine similarity over the corpus, top-5 kept.
+- **Score / Rerank**: `sugiv/stablebridge-pruner-highlighter` cross-encoder, keeps top-3.
+- **Extract / Prune**: same Stablebridge model, second primitive. Returns token-level keep/drop probabilities aggregated into `highlight` / `kept` / `pruned` spans.
+- **LLM context**: the surviving `highlight` and `kept` spans become the compressed context passed downstream. Averages 74% compression vs. the raw reranked passages.
 
 ## Why this example exists
 

--- a/examples/retrieval-ablation/README.md
+++ b/examples/retrieval-ablation/README.md
@@ -1,11 +1,25 @@
-# Production RAG Pipeline for Financial Document Search
+# Find the best retrieval strategy for your RAG
 
-**An evals-driven recipe.** Every model choice below is backed by a
-head-to-head benchmark on 1,854 real queries against 2,942 pages from
-six SEC 10-K filings, measured by NDCG@10. No guesswork, no defaults.
-The recipe at the top is the one that won the evals; the
-[Evidence](#evidence) section lists every other combination tried and
-what each scored.
+RAG quality lives or dies by the retrieval step. Most teams pick a
+retrieval pipeline by feel, by averaged leaderboard scores, or by what
+is already in the stack. None of those tell you how each strategy
+actually performs on your data, so the surprises show up in production.
+
+The cure is straightforward to describe and historically painful to
+run: define a representative benchmark, evaluate every reasonable
+retrieval strategy on it, and pick by a single metric. The painful
+part has always been infrastructure, since most teams give up after
+wiring two or three different model serving stacks.
+
+This example shows what that workflow looks like when one inference
+cluster can serve every retrieval, reranking, and multi-vector model
+the experiment needs. The result is the recipe below, the methodology
+that produced it, and the numbers that ruled out every alternative.
+
+**The setup.** Six bank 10-K filings from SEC EDGAR, 1,854 real
+queries, 2,942 pages, eight retrieval strategies, ranked by NDCG@10.
+The recipe at the top won the evals; the [Evidence](#evidence)
+section lists every other combination tried and what each scored.
 
 One SIE cluster, seven models, three API calls. No model serving to
 manage.

--- a/examples/sie-hugging-face-mteb-semantic-search/README.md
+++ b/examples/sie-hugging-face-mteb-semantic-search/README.md
@@ -49,12 +49,12 @@ the mode you want. The sections below walk through both.
 
 ## Architecture
 
-- **Backend** — Python service in `backend/` (FastAPI + SIE):
+- **Backend**: Python service in `backend/` (FastAPI + SIE):
   - SQLite in `backend/data/sqlite/sie.db` with tables `storage_ids` and `models`.
   - ChromaDB in `backend/data/chroma/` as the local vector store.
   - Superlinked Inference Engine (SIE) produces embeddings for short and long descriptions.
   - OpenRouter generates descriptions from HF metadata + README + MTEB scores.
-- **Frontend** — TypeScript + React app in `frontend/` that calls the backend APIs for search, browse, and model details.
+- **Frontend**: TypeScript + React app in `frontend/` that calls the backend APIs for search, browse, and model details.
 
 ```mermaid
 flowchart LR
@@ -244,7 +244,7 @@ npm run dev
 
 Then open <http://localhost:5173>. For the local demo flow, start with storage id `demo`.
 
-### 3. Check the SIE server — `cli_sie_status.py`
+### 3. Check the SIE server: `cli_sie_status.py`
 
 Inspects liveness, readiness, loaded embedding models, and worker pools.
 
@@ -256,7 +256,7 @@ python cli_sie_status.py --models     # list loaded models
 python cli_sie_status.py --pools      # list worker pools
 ```
 
-### 4. Download model metadata — `cli_download.py`
+### 4. Download model metadata: `cli_download.py`
 
 Selects the top MTEB-benchmarked models (ranked by number of benchmark tasks),
 fetches their Hugging Face metadata in parallel, and stores everything under
@@ -281,7 +281,7 @@ python cli_download.py test01 --dry-run
 Demo READMEs are bundled locally. Live Hugging Face READMEs are fetched on demand
 for downloaded models (see [Operations notes](#operations-notes)).
 
-### 5. Generate descriptions and index — `cli_generate.py`
+### 5. Generate descriptions and index: `cli_generate.py`
 
 Runs the same pipeline as the web UI *Generate Descriptions* buttons:
 
@@ -314,7 +314,7 @@ python cli_generate.py test01 --reindex-only
 python cli_generate.py test01 --dry-run
 ```
 
-### 6. Rebuild the vector index only — `cli_reindex.py`
+### 6. Rebuild the vector index only: `cli_reindex.py`
 
 Drops and rebuilds the `models_{storage_id}` Chroma collection from the
 current SQLite descriptions. Useful if the vector DB is out of sync, or
@@ -332,14 +332,14 @@ python cli_reindex.py test01 --batch-size 16
 
 Single-page React app (`frontend/src/App.tsx`) with four tabs, in this order:
 
-1. **Search with Reranking** — the recommended entry point. Runs a short-description
+1. **Search with Reranking**: the recommended entry point. Runs a short-description
    kNN, then reranks the candidates by long-description similarity. Calls
    `POST /api/search/semantic-rerank`.
-2. **Simple search** — single-stage semantic search on short descriptions. Calls
+2. **Simple search**: single-stage semantic search on short descriptions. Calls
    `POST /api/search/semantic`.
-3. **Download LLM Cards** — triggers `POST /api/models/download` to (re)populate
+3. **Download LLM Cards**: triggers `POST /api/models/download` to (re)populate
    a storage with the top MTEB-benchmarked HF models.
-4. **Browse LLM Cards** — filters stored models by `storage_id` and optional
+4. **Browse LLM Cards**: filters stored models by `storage_id` and optional
    `hf_id` substring; each row opens a full detail view with MTEB scores, the
    live HF README, and a *Generate descriptions* modal.
 
@@ -382,15 +382,15 @@ A full walk-through of the UI fields and modals lives in
 | `long_description`  | varchar(2048)| ≤ 2048 characters                                        |
 
 **Not stored locally:** `readme`, `siblings`, `safetensors`, `spaces`, and the
-raw nested MTEB per-subset/per-split JSON — these would blow SQLite past several
+raw nested MTEB per-subset/per-split JSON: these would blow SQLite past several
 GB across the full catalog.
 
 ### Chroma collection `models_{storage_id}`
 
 Holds **two entries per model**:
 
-- id `"{hf_id}::short"` with `kind="short"` — embedding of `short_description`.
-- id `"{hf_id}::long"`  with `kind="long"`  — embedding of `long_description`.
+- id `"{hf_id}::short"` with `kind="short"`: embedding of `short_description`.
+- id `"{hf_id}::long"` with `kind="long"`: embedding of `long_description`.
 
 Both are produced by the same `SIEEmbeddingFunction`. The `kind` metadata lets
 each search endpoint filter to the right set.
@@ -401,7 +401,7 @@ each search endpoint filter to the right set.
 
 Semantic search lets users describe a task in plain language and find the
 embedding models whose descriptions are closest in meaning. Two endpoints
-are available — a single-stage short-description search and a two-stage
+are available: a single-stage short-description search and a two-stage
 rerank search.
 
 Both share the same request shape:
@@ -414,7 +414,7 @@ Both share the same request shape:
 }
 ```
 
-### `POST /api/search/semantic` — single stage
+### `POST /api/search/semantic`: single stage
 
 Embeds the query, kNN-searches the `kind="short"` entries, returns up to
 `n_results` models sorted by cosine distance.
@@ -431,11 +431,11 @@ Response:
 }
 ```
 
-### `POST /api/search/semantic-rerank` — two stage
+### `POST /api/search/semantic-rerank`: two stage
 
-1. **Stage 1 — short kNN:** `collection.query(query_texts=[query], n_results=N, where={"kind": "short"})`
+1. **Stage 1: short kNN:** `collection.query(query_texts=[query], n_results=N, where={"kind": "short"})`
    returns candidate models with their short-distance scores.
-2. **Stage 2 — long rerank:** `collection.query(query_texts=[query], n_results=len(candidates), where={"$and": [{"kind": "long"}, {"hf_id": {"$in": candidates}}]})`
+2. **Stage 2: long rerank:** `collection.query(query_texts=[query], n_results=len(candidates), where={"$and": [{"kind": "long"}, {"hf_id": {"$in": candidates}}]})`
    makes Chroma recompute cosine distance against only those candidates' long vectors.
 3. Results are merged by `hf_id`, sorted by `rerank_distance` ascending;
    any candidate without a long embedding falls back to `short_distance`
@@ -465,7 +465,7 @@ Response:
 - **Auto:** `POST /api/generate/save` calls `upsert_embedding(storage_id, hf_id, short, long)`
   after every save, keeping both Chroma entries in sync. Clearing a description
   deletes that `kind`'s entry.
-- **Bulk (re)build:** `python cli_reindex.py <storage_id>` — see [How to use](#6-rebuild-the-vector-index-only--cli_reindexpy).
+- **Bulk (re)build:** `python cli_reindex.py <storage_id>`: see [How to use](#6-rebuild-the-vector-index-only--cli_reindexpy).
 
 ---
 
@@ -491,7 +491,7 @@ python cli_download.py <storage_id> --overwrite
 sqlite3 data/sqlite/sie.db "VACUUM;"
 ```
 
-SQLite does not shrink on its own after row deletes — the `VACUUM;` step
+SQLite does not shrink on its own after row deletes: the `VACUUM;` step
 is what actually reclaims disk.
 
 ### Description generation pipeline

--- a/examples/sie-hugging-face-mteb-semantic-search/README.md
+++ b/examples/sie-hugging-face-mteb-semantic-search/README.md
@@ -1,4 +1,4 @@
-# SIE Model Picker
+# Find SOTA embedding models by MTEB task
 
 **You're using SIE and you need to pick a model.** SIE ships 85+
 specialized models for encoding, reranking, and extraction (BGE,

--- a/examples/taxonomy-classification/README.md
+++ b/examples/taxonomy-classification/README.md
@@ -1,4 +1,4 @@
-# Taxonomy Classification with SIE
+# Build a multi-modal product classifier with embeddings
 
 Classify products into a large hierarchical taxonomy using SIE as the unified inference layer.
 

--- a/examples/taxonomy-classification/README.md
+++ b/examples/taxonomy-classification/README.md
@@ -6,7 +6,7 @@ Classify products into a large hierarchical taxonomy using SIE as the unified in
 
 Taxonomy classification assigns a category path (e.g. `Electronics > Computers > Laptops`) to a product given its description or image. Real-world taxonomies are large (10K+ categories), hierarchical (up to 8 levels deep), and ambiguous (multiple categories can be valid for the same product).
 
-Google's [Custom Taxonomy Classifier](https://github.com/google-marketing-solutions/custom-taxonomy-classifier) demonstrates a minimal version of this: embed flat category names with a single Vertex AI model, retrieve the nearest neighbor. This project goes further — we systematically evaluate multiple approaches across text, vision, with and without reranking on a hierarchical taxonomy.
+Google's [Custom Taxonomy Classifier](https://github.com/google-marketing-solutions/custom-taxonomy-classifier) demonstrates a minimal version of this: embed flat category names with a single Vertex AI model, retrieve the nearest neighbor. This project goes further: we systematically evaluate multiple approaches across text, vision, with and without reranking on a hierarchical taxonomy.
 
 ## Why SIE
 
@@ -49,11 +49,11 @@ uv run trim-shopify-dataset-to-l3
 ```
 
 These scripts generate the following files under `data/`:
-- `train-00000-of-00015.parquet` — the raw Shopify train shard downloaded from Hugging Face
-- `shopify-taxonomy-categories.txt` — the raw taxonomy categories file from Shopify
-- `shopify-products-clean-full-depth.parquet` — cleaned dataset with required fields and valid taxonomy labels
-- `shopify-taxonomy-l3.parquet` — taxonomy trimmed to 3 levels
-- `shopify-products-experiment-l3.parquet` — final L3 dataset used by the evaluation scripts
+- `train-00000-of-00015.parquet`: the raw Shopify train shard downloaded from Hugging Face
+- `shopify-taxonomy-categories.txt`: the raw taxonomy categories file from Shopify
+- `shopify-products-clean-full-depth.parquet`: cleaned dataset with required fields and valid taxonomy labels
+- `shopify-taxonomy-l3.parquet`: taxonomy trimmed to 3 levels
+- `shopify-products-experiment-l3.parquet`: final L3 dataset used by the evaluation scripts
 
 To keep evaluation simple, we trim the taxonomy to 3 levels:
 - `26` L1 labels
@@ -61,8 +61,8 @@ To keep evaluation simple, we trim the taxonomy to 3 levels:
 - `1,790` total nodes
 
 We report hierarchical F1 (`hF1`) in two settings:
-- **strict** — only the single `ground_truth_category` counts as correct
-- **lenient** — any label in `potential_product_categories` counts as correct
+- **strict**: only the single `ground_truth_category` counts as correct
+- **lenient**: any label in `potential_product_categories` counts as correct
 
 ## Approaches
 
@@ -364,8 +364,8 @@ With SIE, the interesting part was the modeling, not the infrastructure. We coul
 
 There is still a lot of room to push these results further. A few directions we did not cover here:
 
-- **LLM-enriched category names** — generate richer descriptions for taxonomy nodes, then embed those instead of bare category names.
-- **Hierarchical cascade** — predict L1 first, then L2 inside the chosen branch, then L3.
-- **Fine-tuned embeddings** — train a contrastive model directly on `(product, category)` pairs from the dataset.
+- **LLM-enriched category names**: generate richer descriptions for taxonomy nodes, then embed those instead of bare category names.
+- **Hierarchical cascade**: predict L1 first, then L2 inside the chosen branch, then L3.
+- **Fine-tuned embeddings**: train a contrastive model directly on `(product, category)` pairs from the dataset.
 
 If you want to take this further, try improving the current baselines or inventing a new approach entirely. That is the real takeaway: SIE makes it easy to explore the space quickly.

--- a/examples/wine-recommender/README.md
+++ b/examples/wine-recommender/README.md
@@ -1,6 +1,8 @@
-# WineRetrieval
+# Build a multimodal wine recommender with OCR
 
-WineRetrieval is a runnable demo app that shows how to combine retrieval, reranking, and OCR-style extraction with [SIE](https://superlinked.com/docs/). You can use it to explore wine recommendations from taste preferences, then switch to label detection from an uploaded bottle image.
+Real product flows often need search and extraction at the same time. A user might know they want "something fruity and not too tannic" or they might just have a photo of a bottle they liked. Most stacks would solve those with two separate services and two separate codebases.
+
+This demo wires both into one app on [SIE](https://superlinked.com/docs/). Type taste preferences and get ranked wine recommendations, or upload a bottle photo and get the wine identified from its label. The recommendation flow uses `encode` and `score`. The label flow uses `extract` for OCR. Both run through one SIE endpoint, behind a single Next.js UI.
 
 It wires together two separate prototype features:
 


### PR DESCRIPTION
## Summary

Aligns the example titles across the gallery README and each per-example README with the new SEO-tuned naming used on superlinked.com/docs/examples and the marketing landing page. Adds a softer intro to retrieval-ablation, drops em dashes, and tightens the gallery row descriptions.

## Title changes

| Folder | Old H1 | New H1 |
|--------|--------|--------|
| ecommerce-product-search | E-Commerce Product Search | Self-hosted product search in 5 min |
| retrieval-ablation | Production RAG Pipeline for Financial Document Search | Find the best retrieval strategy for your RAG |
| sie-hugging-face-mteb-semantic-search | SIE Model Picker | Find SOTA embedding models by MTEB task |
| regulatory-rag | Regulatory RAG: Custom Models on SIE | Private fine-tuned compliance RAG |
| wine-recommender | WineRetrieval | Build a multimodal wine recommender with OCR |
| taxonomy-classification | Taxonomy Classification with SIE | Build a multi-modal product classifier with embeddings |

The gallery README link text matches each new H1, and the "Best for" descriptions are tightened to match.

## retrieval-ablation intro

Previously jumped straight into "An evals-driven recipe..." which assumed too much. The new intro sets up:
1. Why retrieval pipeline choice matters for RAG quality.
2. Why most teams skip the eval step (infrastructure pain).
3. What this example shows.

Then introduces the dataset and dives in.

## wine-recommender intro

Reframed around "search and extraction at the same time" instead of the abstract "combine retrieval, reranking, and OCR-style extraction". Concrete user scenarios (typing taste preferences vs uploading a bottle photo) lead the page.

## Em dash cleanup

Removed em dashes from regulatory-rag, sie-hugging-face-mteb-semantic-search, and taxonomy-classification READMEs to match the project style preference.

## Source

Pairs with superlinked/sie-web#59 which applies the same titles to the docs site and landing page cards.