### PR TITLE
docs(readme): add star call-to-action under the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 [![PyPI](https://img.shields.io/pypi/v/sie-sdk?style=flat-square)](https://pypi.org/project/sie-sdk/)
 [![GitHub stars](https://img.shields.io/github/stars/superlinked/sie?style=flat-square)](https://github.com/superlinked/sie/stargazers)
 
+⭐ _Help us reach more developers and grow the SIE community. Star this repo!_
+
 </div>
 
 ## About


### PR DESCRIPTION
Adds a one-line star call-to-action below the header block, in the style of Graphiti's README:

> ⭐ _Help us reach more developers and grow the SIE community. Star this repo!_

Mirrors superlinked/sie-internal#1892 (the README source of truth) so the two stay in sync for the release sync.