### PR TITLE
Add public Docling model alias

### DIFF
--- a/packages/sie_gateway/src/config.rs
+++ b/packages/sie_gateway/src/config.rs
@@ -507,6 +507,10 @@ fn build_model_aliases(overrides: HashMap<String, String>) -> HashMap<String, St
         "guard".to_string(),
         "ibm-granite/granite-guardian-3.0-2b".to_string(),
     );
+    // Docling is package-backed and registered internally as `docling`.
+    // Accept the upstream repository path so public snippets follow the same
+    // org/model shape as weight-backed models.
+    map.insert("docling-project/docling".to_string(), "docling".to_string());
     for (alias, target) in overrides {
         let alias = alias.trim().to_lowercase();
         let target = target.trim().to_string();
@@ -1082,6 +1086,15 @@ mod tests {
         assert_eq!(
             result.get("guard"),
             Some(&"ibm-granite/granite-guardian-3.0-2b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_model_aliases_has_builtin_docling_public_id() {
+        let result = build_model_aliases(HashMap::new());
+        assert_eq!(
+            result.get("docling-project/docling"),
+            Some(&"docling".to_string())
         );
     }
 


### PR DESCRIPTION
## What changed

- accept `docling-project/docling` as a built-in gateway alias for the package-backed `docling` adapter
- keep `docling` as the internal catalog and worker identity
- cover the alias in the gateway configuration tests

This lets public code use the same org/model shape as other model calls without breaking routing or model residency.

## Verification

- `cargo fmt --manifest-path packages/sie_gateway/Cargo.toml --check`
- targeted unit test is included; the local Rust 1.87 toolchain cannot compile the current dependency lockfile, which requires Rust 1.88 or 1.89
