### PR TITLE
chore: scope CodeRabbit to direct content

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+  request_changes_workflow: true
+  auto_review:
+    enabled: false
+    drafts: false
+    labels:
+      - "coderabbit-direct"
+  path_filters:
+    - "examples/**"
+    - "README.md"
+    - "!examples/**/data/**"
+    - "!examples/**/fixtures/**"
+    - "examples/**/fixtures/SOURCES.md"
+    - "!examples/**/verified-run/**"
+    - "examples/**/verified-run/README.md"
+    - "!examples/**/uv.lock"
+  path_instructions:
+    - path: "examples/**"
+      instructions: |
+        Review runnable source, tests, configuration, and documentation.
+        Check that commands match the implementation and that tests cover failure paths.
+        Flag client-side model-name translation and undocumented synthetic results.


### PR DESCRIPTION
## Summary

- opt in CodeRabbit reviews only through the `coderabbit-direct` label
- restrict reviewed paths to `examples/**` and the root `README.md`
- exclude example data, bulk fixtures, verified-run artifacts, and lockfiles
- allow CodeRabbit to submit formal approvals after findings are resolved

This leaves release-managed packages, integrations, deployment content, and other repository paths outside automatic review scope.