### PR TITLE
fix(server): bound Qwen visual context

### DIFF
--- a/packages/sie_server/models/Qwen__Qwen3.5-4B.yaml
+++ b/packages/sie_server/models/Qwen__Qwen3.5-4B.yaml
@@ -151,6 +151,8 @@ profiles:
         # also sets the SGLANG_ENABLE_SPEC_V2=1 env var when
         # speculative.enabled — both are required as a pair.
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
       runtime:
@@ -198,6 +200,8 @@ profiles:
           eagle_topk: 1
           num_draft_tokens: 4
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
           - "--disable-overlap-schedule"
@@ -235,6 +239,8 @@ profiles:
           eagle_topk: 1
           num_draft_tokens: 4
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
       runtime:
@@ -276,6 +282,8 @@ profiles:
         # identical so a config diff between them shows only the
         # speculative block (the intent of the ablation).
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
       runtime:

--- a/packages/sie_server/models/Qwen__Qwen3.6-27B.yaml
+++ b/packages/sie_server/models/Qwen__Qwen3.6-27B.yaml
@@ -118,6 +118,8 @@ profiles:
         # Keep it paired with ``--disable-overlap-schedule`` for all NEXTN
         # launch profiles.
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
           - "--disable-overlap-schedule"
@@ -160,6 +162,8 @@ profiles:
         # NEXTN + mamba-scheduler ``extra_buffer`` on the hybrid Gated-
         # DeltaNet architecture (same constraint as Qwen3.5-4B).
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
           - "--disable-overlap-schedule"
@@ -200,6 +204,8 @@ profiles:
         speculative:
           enabled: false
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--quantization"
           - "fp8"
   # RTX PRO 6000 (96 GB GDDR7, Blackwell Server Edition, sm_120) profile.
@@ -269,6 +275,8 @@ profiles:
         # companions on the hybrid Gated-DeltaNet architecture. List is the
         # FULL set (production full-replaces ``extra_launch_args``, not merge).
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--quantization"
           - "fp8"
           - "--mamba-scheduler-strategy"
@@ -339,6 +347,8 @@ profiles:
         speculative:
           enabled: false
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--cuda-graph-max-bs"
           - "32"
       runtime:
@@ -375,6 +385,8 @@ profiles:
         speculative:
           enabled: false
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--mamba-scheduler-strategy"
           - "extra_buffer"
           - "--disable-overlap-schedule"
@@ -382,11 +394,12 @@ profiles:
         first_chunk_timeout_s: 90
         inter_chunk_timeout_s: 15
         overall_timeout_s: 600
+        # A strict grammar may complete valid JSON in fewer than ten tokens.
+        # Do not force post-schema tokens on grammar-routed profiles.
         default_sampling:
           temperature: 0.7
           top_p: 0.8
           top_k: 20
           presence_penalty: 1.5
-          min_new_tokens: 10
         stop_tokens:
           - "<|im_end|>"

--- a/packages/sie_server/models/Qwen__Qwen3.6-35B-A3B.yaml
+++ b/packages/sie_server/models/Qwen__Qwen3.6-35B-A3B.yaml
@@ -43,6 +43,8 @@ profiles:
         speculative:
           enabled: false
         extra_launch_args:
+          - "--mm-process-config"
+          - '{"image":{"max_pixels":1003520}}'
           - "--quantization"
           - "fp8"
       runtime:

--- a/packages/sie_server/src/sie_server/adapters/sglang/_compat/sitecustomize.py
+++ b/packages/sie_server/src/sie_server/adapters/sglang/_compat/sitecustomize.py
@@ -1,0 +1,92 @@
+"""Backport SGLang multimodal processor configuration forwarding.
+
+SGLang 0.5.10 parses ``--mm-process-config`` and stores its per-modality
+settings, but its base processor does not forward the image settings to the
+Hugging Face processor. Upstream #18467 now passes them as ``images_kwargs``.
+This site hook runs only in the SGLang generation subprocess and can be removed
+when the shared bundle advances to a release containing that fix.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+_BASE_PROCESSOR_MODULE = "sglang.srt.multimodal.processors.base_processor"
+_CLASS_PATCH_MARKER = "_sie_mm_process_config_compat"
+_IMPORT_HOOK_MARKER = "_sie_mm_process_config_deferred_compat"
+
+
+def _patch_base_processor_module(module: ModuleType) -> None:
+    processor_class = getattr(module, "BaseMultimodalProcessor", None)
+    if processor_class is None:
+        raise RuntimeError(f"{_BASE_PROCESSOR_MODULE} does not expose BaseMultimodalProcessor")
+    if getattr(processor_class, _CLASS_PATCH_MARKER, False):
+        return
+
+    original_process = processor_class.process_mm_data
+
+    @wraps(original_process)
+    def compat_process(
+        self: Any,
+        input_text: Any,
+        images: Any = None,
+        videos: Any = None,
+        audios: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        image_config = getattr(self, "image_config", None)
+        if images and isinstance(image_config, dict) and image_config:
+            kwargs.setdefault("images_kwargs", {}).update(image_config)
+        return original_process(
+            self,
+            input_text,
+            images=images,
+            videos=videos,
+            audios=audios,
+            **kwargs,
+        )
+
+    processor_class.process_mm_data = compat_process
+    setattr(processor_class, _CLASS_PATCH_MARKER, True)
+
+
+def _install_mm_process_config_compat() -> None:
+    loaded = sys.modules.get(_BASE_PROCESSOR_MODULE)
+    if isinstance(loaded, ModuleType):
+        _patch_base_processor_module(loaded)
+        return
+
+    current_import = builtins.__import__
+    if getattr(current_import, _IMPORT_HOOK_MARKER, False):
+        return
+
+    def deferred_import(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: Sequence[str] | None = (),
+        level: int = 0,
+    ) -> ModuleType:
+        module = current_import(name, globals, locals, fromlist, level)
+        loaded_module = sys.modules.get(_BASE_PROCESSOR_MODULE)
+        if not isinstance(loaded_module, ModuleType) or not hasattr(loaded_module, "BaseMultimodalProcessor"):
+            return module
+        try:
+            _patch_base_processor_module(loaded_module)
+        finally:
+            if builtins.__import__ is deferred_import:
+                setattr(builtins, "__import__", current_import)  # noqa: B010
+        return module
+
+    setattr(deferred_import, _IMPORT_HOOK_MARKER, True)
+    setattr(builtins, "__import__", deferred_import)  # noqa: B010
+
+
+if os.environ.get("SIE_SGLANG_MM_PROCESS_CONFIG_COMPAT") == "1":
+    _install_mm_process_config_compat()

--- a/packages/sie_server/src/sie_server/adapters/sglang/generation.py
+++ b/packages/sie_server/src/sie_server/adapters/sglang/generation.py
@@ -156,6 +156,19 @@ def _encode_image_data(images: list[ImageInput] | None) -> list[str] | None:
     return encoded
 
 
+def _raise_for_sglang_event_error(event: Any) -> None:
+    """Propagate an error carried inside SGLang's HTTP-200 SSE stream."""
+    if not isinstance(event, dict) or "error" not in event:
+        return
+    error = event["error"]
+    message = error.get("message") if isinstance(error, dict) else error
+    if not isinstance(message, str) or not message.strip():
+        message = "unknown in-band SGLang error"
+    message = message.strip()[:500]
+    logger.error("SGLang /generate in-band error: %s", message)
+    raise RuntimeError(f"SGLang /generate error: {message}")
+
+
 def _tail_file(path: str, *, max_lines: int = 200) -> str:
     """Return the final lines from a startup log for diagnostics."""
     try:
@@ -498,6 +511,10 @@ class SGLangGenerationAdapter(GenerationAdapter):
                     "speculative_needs_extra_buffer=false (non-DeltaNet models e.g. Gemma 4 "
                     "MTP), or disable speculative.enabled in the model config."
                 )
+        compat_dir = os.path.join(os.path.dirname(__file__), "_compat")
+        inherited_pythonpath = os.environ.get("PYTHONPATH", "")
+        extra_env["PYTHONPATH"] = os.pathsep.join(path for path in (compat_dir, inherited_pythonpath) if path)
+        extra_env["SIE_SGLANG_MM_PROCESS_CONFIG_COMPAT"] = "1"
         logger.warning(
             "Resolved SGLang generation command: %s",
             " ".join(shlex.quote(str(arg)) for arg in cmd),
@@ -1112,6 +1129,7 @@ class SGLangGenerationAdapter(GenerationAdapter):
                         event = json.loads(line)
                     except json.JSONDecodeError:
                         continue
+                    _raise_for_sglang_event_error(event)
                     idx = int(event.get("index", 0))
                     cumulative = event.get("text", "")
                     if not isinstance(cumulative, str):
@@ -1402,6 +1420,7 @@ class SGLangGenerationAdapter(GenerationAdapter):
                         logger.warning("SGLang stream: skipping non-JSON line: %s", line[:200])
                         continue
 
+                    _raise_for_sglang_event_error(event)
                     chunk = _chunk_from_sglang_event(
                         event,
                         previous_cumulative_text=last_cumulative_text,

--- a/packages/sie_server/src/sie_server/processors/streaming.py
+++ b/packages/sie_server/src/sie_server/processors/streaming.py
@@ -248,10 +248,12 @@ _MAX_IMAGES_PER_REQUEST = 16
 # admission reservation. The chat template renders each image as a short
 # placeholder, but the vision encoder expands it into many tokens (Qwen-VL:
 # up to ~1280 at max_pixels). Exact counts need the image dimensions + the
-# model's vision tokenizer, which we don't have at this layer — so we use a
-# conservative constant. Over-reserving is safe; under-counting risks a
-# context-window overflow (opaque SGLang error) and admission over-admit.
-_VISION_TOKENS_PER_IMAGE_ESTIMATE = 1024
+# model's vision tokenizer, which we don't have at this layer. Qwen SGLang
+# profiles cap preprocessing at 1280 visual tokens, so this value is both a
+# conservative reservation and a hard upper bound for the image-capable
+# generation family. Under-counting risks a context-window overflow and
+# admission over-admit.
+_VISION_TOKENS_PER_IMAGE_ESTIMATE = 1280
 
 # Hard ceiling on a single decoded image's bytes. Bounds worker memory on the
 # decode path even for the direct-queue caller that bypasses the gateway's

--- a/packages/sie_server/tests/adapters/test_sglang_generation.py
+++ b/packages/sie_server/tests/adapters/test_sglang_generation.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import os
+import subprocess
+import sys
+from pathlib import Path
 from typing import Any, Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -124,6 +128,10 @@ def test_load_drops_is_embedding(
     assert cmd[cmd.index("--grammar-backend") + 1] == "outlines"
     assert "--served-model-name" in cmd
     assert adapter._server_url == "http://localhost:30005"
+    child_env = mock_popen.call_args.kwargs["env"]
+    assert child_env["SIE_SGLANG_MM_PROCESS_CONFIG_COMPAT"] == "1"
+    expected_compat_dir = Path(__file__).resolve().parents[2] / "src/sie_server/adapters/sglang/_compat"
+    assert child_env["PYTHONPATH"].split(os.pathsep)[0] == str(expected_compat_dir)
 
 
 @patch("sie_server.adapters.sglang._server.wait_for_server", return_value=True)
@@ -296,6 +304,28 @@ def test_generate_streams_sse_into_chunks(mock_async_client: MagicMock, adapter)
     assert chunks[-1].finish_reason == "stop"
     assert chunks[-1].prompt_tokens == 5
     assert chunks[-1].completion_tokens == 3
+
+
+@patch("sie_server.adapters.sglang.generation.httpx.AsyncClient")
+def test_generate_surfaces_in_band_sglang_error(mock_async_client: MagicMock, adapter) -> None:
+    stream = _FakeStreamingResponse(
+        [
+            'data: {"error": {"message": "vision processor rejected image"}}',
+            "data: [DONE]",
+        ]
+    )
+    mock_async_client.return_value = _make_client_with_stream(stream)
+    adapter._server_url = "http://localhost:30005"
+
+    async def _collect() -> None:
+        async for _ in adapter.generate(prompt="Hi", max_new_tokens=8):
+            pass
+
+    with pytest.raises(
+        RuntimeError,
+        match="SGLang /generate error: vision processor rejected image",
+    ):
+        asyncio.run(_collect())
 
 
 @patch("sie_server.adapters.sglang.generation.httpx.AsyncClient")
@@ -1775,3 +1805,64 @@ def test_non_guard_model_streaming_unaffected(mock_async_client: MagicMock, adap
     # Client didn't request logprobs and the model isn't a guard → all None.
     assert all(c.logprobs is None for c in chunks)
     assert any(c.done for c in chunks)
+
+
+def test_mm_process_config_compat_forwards_image_kwargs(tmp_path: Path) -> None:
+    package_root = tmp_path / "fake-package"
+    processors = package_root / "sglang" / "srt" / "multimodal" / "processors"
+    processors.mkdir(parents=True)
+    package_dirs = (
+        package_root / "sglang",
+        package_root / "sglang" / "srt",
+        package_root / "sglang" / "srt" / "multimodal",
+        processors,
+    )
+    for package in package_dirs:
+        (package / "__init__.py").write_text("", encoding="utf-8")
+    (processors / "base_processor.py").write_text(
+        """class BaseMultimodalProcessor:
+    def __init__(self):
+        self.image_config = {"max_pixels": 1003520}
+
+    def process_mm_data(self, input_text, images=None, videos=None, audios=None, **kwargs):
+        return kwargs
+""",
+        encoding="utf-8",
+    )
+
+    compat_dir = Path(__file__).resolve().parents[2] / "src/sie_server/adapters/sglang/_compat"
+    script = """import sitecustomize
+
+sitecustomize._install_mm_process_config_compat()
+sitecustomize._install_mm_process_config_compat()
+
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+sitecustomize._patch_base_processor_module(__import__(
+    "sglang.srt.multimodal.processors.base_processor",
+    fromlist=["BaseMultimodalProcessor"],
+))
+processor = BaseMultimodalProcessor()
+assert processor.process_mm_data("x", images=[b"image"]) == {
+    "images_kwargs": {"max_pixels": 1003520}
+}
+assert processor.process_mm_data("x", images=None) == {}
+assert not hasattr(BaseMultimodalProcessor.process_mm_data.__wrapped__, "__wrapped__")
+print("mm-process-config-ready")
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join((str(compat_dir), str(package_root)))
+    env["SIE_SGLANG_MM_PROCESS_CONFIG_COMPAT"] = "1"
+
+    completed = subprocess.run(  # noqa: S603 - executes the fixed local interpreter
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Error in sitecustomize" not in completed.stderr
+    assert completed.stdout.strip() == "mm-process-config-ready"

--- a/packages/sie_server/tests/config/test_qwen_generation_profiles.py
+++ b/packages/sie_server/tests/config/test_qwen_generation_profiles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import yaml
@@ -9,6 +10,11 @@ _QWEN35_MODEL_PATH = Path(__file__).resolve().parents[2] / "models" / "Qwen__Qwe
 _ADAPTER = "sie_server.adapters.sglang.generation:SGLangGenerationAdapter"
 _MLX_REPO = "mlx-community/Qwen3.5-4B-4bit"
 _QWEN36_MODEL_PATH = Path(__file__).resolve().parents[2] / "models" / "Qwen__Qwen3.6-27B.yaml"
+_QWEN36_35B_MODEL_PATH = Path(__file__).resolve().parents[2] / "models" / "Qwen__Qwen3.6-35B-A3B.yaml"
+_MM_PROCESS_CONFIG_ARGS = [
+    "--mm-process-config",
+    '{"image":{"max_pixels":1003520}}',
+]
 
 
 def _qwen35_config() -> ModelConfig:
@@ -46,6 +52,7 @@ def test_qwen35_default_resolves_to_measured_a100_shape() -> None:
         "num_draft_tokens": 4,
     }
     assert default.loadtime["extra_launch_args"] == [
+        *_MM_PROCESS_CONFIG_ARGS,
         "--mamba-scheduler-strategy",
         "extra_buffer",
     ]
@@ -63,6 +70,7 @@ def test_qwen35_l4_smoke_preserves_constrained_c1_shape() -> None:
     assert l4_smoke.loadtime["mem_fraction_static"] == 0.90
     assert l4_smoke.loadtime["speculative"]["enabled"] is True
     assert l4_smoke.loadtime["extra_launch_args"] == [
+        *_MM_PROCESS_CONFIG_ARGS,
         "--mamba-scheduler-strategy",
         "extra_buffer",
         "--disable-overlap-schedule",
@@ -127,7 +135,11 @@ def test_qwen36_grammar_requests_route_to_no_spec() -> None:
     assert h100_fp8.adapter_path == no_spec.adapter_path
     assert h100_fp8.runtime == no_spec.runtime
     assert h100_fp8.loadtime["speculative"] == {"enabled": False}
-    assert h100_fp8.loadtime["extra_launch_args"] == ["--quantization", "fp8"]
+    assert h100_fp8.loadtime["extra_launch_args"] == [
+        *_MM_PROCESS_CONFIG_ARGS,
+        "--quantization",
+        "fp8",
+    ]
     assert default.loadtime["grammar_backend"] == no_spec.loadtime["grammar_backend"] == "outlines"
     assert default.loadtime["speculative"] == {
         "enabled": False,
@@ -139,18 +151,21 @@ def test_qwen36_grammar_requests_route_to_no_spec() -> None:
     assert no_spec.loadtime["speculative"] == {"enabled": False}
 
 
-def test_qwen36_profiles_use_official_non_thinking_sampling_defaults() -> None:
+def test_qwen36_minimum_tokens_are_limited_to_free_text_profiles() -> None:
     config = ModelConfig.model_validate(yaml.safe_load(_QWEN36_MODEL_PATH.read_text()))
-    expected = {
+    base_sampling = {
         "temperature": 0.7,
         "top_p": 0.8,
         "top_k": 20,
         "presence_penalty": 1.5,
-        "min_new_tokens": 10,
     }
 
-    for profile_name in ("default", "h100", "h100-fp8", "rtx-pro-6000", "batch", "no-spec"):
-        assert config.resolve_profile(profile_name).runtime["default_sampling"] == expected
+    for profile_name in ("default", "h100", "rtx-pro-6000", "batch"):
+        assert config.resolve_profile(profile_name).runtime["default_sampling"] == (
+            base_sampling | {"min_new_tokens": 10}
+        )
+    for profile_name in ("no-spec", "h100-fp8"):
+        assert config.resolve_profile(profile_name).runtime["default_sampling"] == base_sampling
 
 
 def test_qwen36_base_profiles_expose_8k_context() -> None:
@@ -164,3 +179,21 @@ def test_qwen36_base_profiles_expose_8k_context() -> None:
     assert config.resolve_profile("h100-fp8").kv_budget_tokens == 16384
     assert config.resolve_profile("batch").kv_budget_tokens == 32768
     assert config.resolve_profile("no-spec").kv_budget_tokens == 65536
+
+
+def test_all_qwen_vlm_profiles_cap_image_preprocessing() -> None:
+    for model_path in (
+        _QWEN35_MODEL_PATH,
+        _QWEN36_MODEL_PATH,
+        _QWEN36_35B_MODEL_PATH,
+    ):
+        config = ModelConfig.model_validate(yaml.safe_load(model_path.read_text()))
+        assert config.inputs.image is True
+        for profile_name in config.profiles:
+            profile = config.resolve_profile(profile_name)
+            if profile.adapter_path != _ADAPTER:
+                continue
+            args = profile.loadtime["extra_launch_args"]
+            assert args.count("--mm-process-config") == 1
+            index = args.index("--mm-process-config")
+            assert json.loads(args[index + 1]) == {"image": {"max_pixels": 1280 * 28 * 28}}

--- a/packages/sie_server/tests/processors/test_streaming.py
+++ b/packages/sie_server/tests/processors/test_streaming.py
@@ -2910,3 +2910,48 @@ async def test_messages_image_reaches_adapter(monkeypatch: pytest.MonkeyPatch) -
     assert len(adapter.received_images) == 1
     assert adapter.received_images[0]["data"] == b"catbytes"
     assert adapter.received_images[0]["format"] == "png"
+
+
+@pytest.mark.asyncio
+async def test_streaming_processor_reserves_capped_visual_tokens(monkeypatch) -> None:
+    nc = AsyncMock()
+    adapter = _FakeGenAdapter([])
+    registry = _make_registry_with_chat_config(adapter, context_length=1200)
+
+    class _StubTok:
+        def apply_chat_template(self, *args, **kwargs):
+            return "rendered"
+
+        def encode(self, text, *, add_special_tokens):
+            return [0]
+
+    from sie_server.processors import streaming as streaming_mod
+
+    monkeypatch.setattr(streaming_mod, "load_tokenizer", lambda *args, **kwargs: _StubTok())
+
+    proc = StreamingProcessor(nc=nc, registry=registry, worker_id="w1")
+    wi = _make_work_item(
+        generate={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "inspect this image",
+                    "images": [
+                        {
+                            "data": base64.b64encode(b"image").decode(),
+                            "format": "png",
+                        }
+                    ],
+                }
+            ],
+            "max_new_tokens": 64,
+        }
+    )
+    msg = _make_msg(wi)
+    await proc.process(msg, "test/model")
+
+    terminal = _decode_chunks(nc)[-1]
+    assert terminal["done"] is True
+    assert terminal["error"]["code"] == "context_exceeded"
+    assert "~image_tokens (1280)" in terminal["error"]["message"]
+    msg.ack.assert_awaited_once()


### PR DESCRIPTION
## Summary

- cap image preprocessing for every Qwen 3.5/3.6 SGLang VLM profile at 1,280 visual tokens and reserve the same amount in worker admission
- backport SGLang #18467 into the pinned 0.5.10 child process so `--mm-process-config` is actually forwarded to the Hugging Face image processor
- surface HTTP-200 in-band SGLang generation errors and keep strict Qwen 3.6 grammar output from forcing tokens past a completed schema

The compatibility hook is isolated to the SGLang subprocess and has an explicit removal reference for the next engine upgrade.

## Validation

- `ruff check` and `ruff format --check` on all modified Python files
- `ty check` on the modified serving modules
- Qwen profile tests: 9 passed
- SGLang generation adapter tests: 80 passed
- streaming processor tests: 78 passed
