### PR TITLE
feat(models): add PaddleOCR-VL-1.6

### DIFF
--- a/examples/document-ocr/README.md
+++ b/examples/document-ocr/README.md
@@ -196,7 +196,7 @@ GPU-only models show up disabled on the CPU compose).
 
 | Stage | Default (preloaded) | Alternates |
 |---|---|---|
-| Recognition | `lightonai/LightOnOCR-2-1B` (2.1B, Markdown output) | `PaddlePaddle/PaddleOCR-VL-1.5` (GPU image); `zai-org/GLM-OCR` (9B, GPU only) |
+| Recognition | `lightonai/LightOnOCR-2-1B` (2.1B, Markdown output) | `PaddlePaddle/PaddleOCR-VL-1.6` (GPU image); `zai-org/GLM-OCR` (9B, GPU only) |
 | Structured | `naver-clova-ix/donut-base-finetuned-cord-v2` | `naver-clova-ix/donut-base-finetuned-docvqa`; `naver-clova-ix/donut-base-finetuned-rvlcdip` (16-class document classifier) |
 | Zero-shot NER | `urchade/gliner_multi-v2.1` | `urchade/gliner_large-v2.1`; `urchade/gliner_multi_pii-v1`; `numind/NuNER_Zero` (different architecture, useful contrast against GLiNER) |
 

--- a/examples/document-ocr/compose.gpu.yml
+++ b/examples/document-ocr/compose.gpu.yml
@@ -11,7 +11,7 @@ services:
       - --port
       - "8080"
       - --preload
-      - lightonai/LightOnOCR-2-1B,naver-clova-ix/donut-base-finetuned-cord-v2,urchade/gliner_multi-v2.1,zai-org/GLM-OCR,PaddlePaddle/PaddleOCR-VL-1.5
+      - lightonai/LightOnOCR-2-1B,naver-clova-ix/donut-base-finetuned-cord-v2,urchade/gliner_multi-v2.1,zai-org/GLM-OCR,PaddlePaddle/PaddleOCR-VL-1.6
     ports:
       - "8080:8080"
     restart: unless-stopped

--- a/examples/document-ocr/src/config.ts
+++ b/examples/document-ocr/src/config.ts
@@ -14,9 +14,9 @@ export const RECOGNITION_MODELS: ModelOption[] = [
     description: "Pixtral encoder + Qwen3 decoder, 2.1B. Strong Markdown output across dense layouts. ~4 GB to download on first call.",
   },
   {
-    id: "PaddlePaddle/PaddleOCR-VL-1.5",
-    label: "PaddleOCR-VL-1.5 (GPU image)",
-    description: "Paddle's VLM-OCR, 1.5B. Six task modes. Available on the CUDA image (compose.gpu.yml).",
+    id: "PaddlePaddle/PaddleOCR-VL-1.6",
+    label: "PaddleOCR-VL-1.6 (GPU image)",
+    description: "Paddle's VLM-OCR, 0.9B. Six task modes. Available on the CUDA image (compose.gpu.yml).",
     options: { task: "ocr" },
     gpuRequired: true,
   },

--- a/packages/sie_server/models/PaddlePaddle__PaddleOCR-VL-1.6.yaml
+++ b/packages/sie_server/models/PaddlePaddle__PaddleOCR-VL-1.6.yaml
@@ -1,0 +1,54 @@
+sie_id: PaddlePaddle/PaddleOCR-VL-1.6
+hf_id: PaddlePaddle/PaddleOCR-VL-1.6
+hf_revision: cdc88f5feff0e4079e75863205053a68358e52f7
+inputs:
+  text: false
+  image: true
+  audio: false
+  video: false
+tasks:
+  encode: null
+  score: null
+  extract: {}
+max_sequence_length: 16384
+profiles:
+  transformers:
+    max_batch_tokens: 16384
+    compute_precision: bfloat16
+    adapter_path: sie_server.adapters.paddleocr_vl:PaddleOCRVLAdapter
+    adapter_options:
+      loadtime:
+        trust_remote_code: true
+        default_task: ocr
+      runtime:
+        task: ocr
+        max_new_tokens: 4096
+        num_beams: 1
+  default:
+    max_batch_tokens: 16384
+    compute_precision: bfloat16
+    adapter_path: sie_server.adapters.sglang_vision_extract.adapter:SGLangVisionExtractAdapter
+    adapter_options:
+      loadtime:
+        trust_remote_code: true
+        mem_fraction_static: 0.85
+        served_model_name: PaddlePaddle/PaddleOCR-VL-1.6
+        max_concurrent_requests: 16
+        processor_use_fast: false
+        extra_launch_args:
+          - --disable-fast-image-processor
+        default_task: ocr
+        task_prompts:
+          ocr: "OCR:"
+          table: "Table Recognition:"
+          formula: "Formula Recognition:"
+          chart: "Chart Recognition:"
+          spotting: "Spotting:"
+          seal: "Seal Recognition:"
+        task_labels:
+          spotting: spotting
+          seal: seal
+      runtime:
+        task: ocr
+        max_new_tokens: 4096
+        num_beams: 1

--- a/packages/sie_server/src/sie_server/adapters/paddleocr_vl/__init__.py
+++ b/packages/sie_server/src/sie_server/adapters/paddleocr_vl/__init__.py
@@ -25,7 +25,7 @@ _ERR_NO_IMAGES = "PaddleOCRVLAdapter requires image input for extraction"
 _ERR_ENCODE_NOT_SUPPORTED = "PaddleOCRVLAdapter does not support encode(). Use extract() instead."
 _ERR_FP16_UNSUPPORTED = "PaddleOCR-VL does not support float16 on CUDA (config pins bfloat16); use bfloat16 or float32."
 
-# Canonical task -> prompt mapping from the PaddleOCR-VL-1.5 model card.
+# Canonical task -> prompt mapping from the PaddleOCR-VL model card.
 # Keep in sync with preprocessor/vision.py::_PADDLEOCR_VL_TASK_PROMPTS.
 _TASK_PROMPTS: dict[str, str] = {
     "ocr": "OCR:",
@@ -44,8 +44,8 @@ _COMPAT_PATCHED_ATTR = "_sie_paddleocr_vl_compat_patched"
 def _apply_transformers_compat_shim() -> None:
     """Bridge a parameter rename so PaddleOCR-VL's modeling code loads.
 
-    PaddleOCR-VL-1.5's custom modeling code (pinned at revision
-    6819afc8509ac9afa50e91b34627a7cf8f7900bb) calls
+    PaddleOCR-VL's custom modeling code (byte-identical across the pinned 1.5
+    and 1.6 revisions) calls
     ``transformers.masking_utils.create_causal_mask(inputs_embeds=...)``,
     but the signature in transformers 4.57.x uses ``input_embeds`` (singular).
     Without this shim, ``model.generate()`` raises:
@@ -76,9 +76,9 @@ def _apply_transformers_compat_shim() -> None:
 
 
 class PaddleOCRVLAdapter(BaseAdapter):
-    """Adapter for PaddlePaddle/PaddleOCR-VL-1.5 OCR VLM.
+    """Adapter for the PaddlePaddle/PaddleOCR-VL OCR VLMs (1.5, 1.6).
 
-    PaddleOCR-VL-1.5 is a 0.9B-param autoregressive VLM combining a NaViT-style
+    PaddleOCR-VL is a 0.9B-param autoregressive VLM combining a NaViT-style
     SigLIP vision encoder with an ERNIE-4.5-0.3B decoder. Supports 109
     languages and six task modes: ocr, table, formula, chart, spotting, seal.
 

--- a/packages/sie_server/src/sie_server/core/prepared.py
+++ b/packages/sie_server/src/sie_server/core/prepared.py
@@ -301,7 +301,7 @@ LightOnOCRPreparedItem = PreparedItem[LightOnOCRPayload]
 class PaddleOCRVLPayload(Payload):
     """Preprocessed PaddleOCR-VL input ready for extraction.
 
-    PaddleOCR-VL-1.5 combines a NaViT-style SigLIP vision encoder with an
+    PaddleOCR-VL combines a NaViT-style SigLIP vision encoder with an
     ERNIE-4.5-0.3B decoder. The processor tokenizes a chat-template prompt
     and emits a Qwen-VL-style ``image_grid_thw`` alongside ``pixel_values``.
     """

--- a/packages/sie_server/src/sie_server/core/preprocessor/vision.py
+++ b/packages/sie_server/src/sie_server/core/preprocessor/vision.py
@@ -1416,7 +1416,7 @@ class DetectionPreprocessor:
         }
 
 
-# Canonical task -> prompt mapping from the PaddleOCR-VL-1.5 model card
+# Canonical task -> prompt mapping from the PaddleOCR-VL model card
 # (PROMPTS dict in the README; trailing colons included). Keep in sync with
 # PaddleOCRVLAdapter._VALID_TASKS.
 _PADDLEOCR_VL_TASK_PROMPTS: dict[str, str] = {

--- a/packages/sie_server/tests/adapters/test_paddleocr_vl.py
+++ b/packages/sie_server/tests/adapters/test_paddleocr_vl.py
@@ -15,7 +15,14 @@ _ = transformers.AutoProcessor
 _ = transformers.AutoModelForCausalLM
 _ = transformers.masking_utils.create_causal_mask
 
-_MODEL_PATH = Path(__file__).resolve().parents[2] / "models" / "PaddlePaddle__PaddleOCR-VL-1.5.yaml"
+_MODELS_DIR = Path(__file__).resolve().parents[2] / "models"
+
+# Both catalog versions share this adapter: their custom modeling code is
+# byte-identical upstream, so each pinned revision must keep resolving.
+_CATALOG_VERSIONS = [
+    ("PaddlePaddle/PaddleOCR-VL-1.5", "6819afc8509ac9afa50e91b34627a7cf8f7900bb"),
+    ("PaddlePaddle/PaddleOCR-VL-1.6", "cdc88f5feff0e4079e75863205053a68358e52f7"),
+]
 
 
 class TestPaddleOCRVLAdapter:
@@ -327,21 +334,26 @@ class TestPaddleOCRVLAdapter:
 
         assert mock_model.generate.call_args.kwargs["use_cache"] is True
 
-    def test_yaml_config_loads(self) -> None:
+    @pytest.mark.parametrize(("sie_id", "hf_revision"), _CATALOG_VERSIONS)
+    def test_yaml_config_loads(self, sie_id: str, hf_revision: str) -> None:
         """The shipped model YAML parses and resolves an adapter path."""
         import yaml
         from sie_server.config.model import ModelConfig
 
-        with _MODEL_PATH.open() as f:
+        yaml_path = _MODELS_DIR / f"{sie_id.replace('/', '__')}.yaml"
+        with yaml_path.open() as f:
             data = yaml.safe_load(f)
         config = ModelConfig(**data)
-        assert config.sie_id == "PaddlePaddle/PaddleOCR-VL-1.5"
-        assert config.hf_id == "PaddlePaddle/PaddleOCR-VL-1.5"
-        assert config.hf_revision == "6819afc8509ac9afa50e91b34627a7cf8f7900bb"
+        assert config.sie_id == sie_id
+        assert config.hf_id == sie_id
+        assert config.hf_revision == hf_revision
         assert config.inputs.image is True
         resolved = config.resolve_profile("default")
         assert resolved.adapter_path == "sie_server.adapters.sglang_vision_extract.adapter:SGLangVisionExtractAdapter"
         assert resolved.compute_precision == "bfloat16"
+        # A stale served_model_name silently serves the wrong weights under the
+        # right id, so pin it to sie_id rather than leaving it to review.
+        assert resolved.loadtime["served_model_name"] == sie_id
         fallback = config.resolve_profile("transformers")
         assert fallback.adapter_path == "sie_server.adapters.paddleocr_vl:PaddleOCRVLAdapter"
         assert fallback.compute_precision == "bfloat16"

--- a/packages/sie_server/tests/config/test_bundle_coverage.py
+++ b/packages/sie_server/tests/config/test_bundle_coverage.py
@@ -141,6 +141,7 @@ def test_candle_bundle_only_exposes_profile_variants() -> None:
     [
         ("lightonai/LightOnOCR-2-1B", "transformers5.yaml"),
         ("PaddlePaddle/PaddleOCR-VL-1.5", "default.yaml"),
+        ("PaddlePaddle/PaddleOCR-VL-1.6", "default.yaml"),
         ("zai-org/GLM-OCR", "transformers5.yaml"),
     ],
 )


### PR DESCRIPTION
Adds `PaddlePaddle/PaddleOCR-VL-1.6` to the catalog. 1.5 stays, per the Qwen3.5/3.6 precedent.

1.6 is a drop-in successor: `config.json`, `preprocessor_config.json`, `modeling_paddleocr_vl.py`,
`processing_paddleocr_vl.py` and `image_processing_paddleocr_vl.py` are byte-identical to 1.5,
only the weights changed. The adapter, the `create_causal_mask` shim, the bfloat16 pin and the
task prompts all carry over, so the new YAML is the whole registration.

`test_yaml_config_loads` is parametrized over both versions instead of duplicated, and now asserts
`served_model_name == sie_id`: a stale value there serves the wrong weights under the right id and
nothing catches it. The `document-ocr` example moves to 1.6; its description said 1.5B, the model
is 0.9B.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the PaddleOCR-VL 1.6 recognition model.
  * Updated document OCR examples and GPU setup to use PaddleOCR-VL 1.6.
  * Added model configuration with vision extraction, OCR prompts, and runtime settings.

* **Bug Fixes**
  * Expanded OCR model validation and coverage to include both supported model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->