### PR TITLE
chore: add repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @superlinked/core-team


### PR DESCRIPTION
## Summary

- assign all repository paths to `@superlinked/core-team`
- activate the existing code-owner review requirement without increasing the one-approval policy

## Validation

- `git diff --check`
- confirmed `core-team` has maintain access
- confirmed the active `main` ruleset requires one approval and a code-owner review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-wide ownership coverage for project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->