### PR TITLE
fix(server): pin cuda-tile for TensorRT-LLM

### DIFF
--- a/packages/sie_server/bundles/tensorrt-llm.yaml
+++ b/packages/sie_server/bundles/tensorrt-llm.yaml
@@ -17,6 +17,8 @@ deps:
   torch: '==2.11.0'
   transformers: '==5.5.4'
   flashinfer-python: '==0.6.16'
+  # Keep the qualified build stable when the image resolver permits prereleases.
+  cuda-tile: '==1.6.0rc8'
   triton: '==3.6.0'
   nvidia-cutlass-dsl: '==4.5.0'
   nvidia-cuda-tileiras: '==13.1.80'

--- a/packages/sie_server/tests/config/test_bundle_coverage.py
+++ b/packages/sie_server/tests/config/test_bundle_coverage.py
@@ -123,6 +123,12 @@ def test_bundle_and_model_dirs_are_non_empty() -> None:
     assert sorted(MODELS_DIR.glob("*.yaml")), f"No model YAML files found in {MODELS_DIR}"
 
 
+def test_tensorrt_llm_bundle_pins_qualified_cuda_tile() -> None:
+    bundle = yaml.safe_load((BUNDLES_DIR / "tensorrt-llm.yaml").read_text()) or {}
+
+    assert bundle["deps"]["cuda-tile"] == "==1.6.0rc8"
+
+
 def test_candle_bundle_only_exposes_profile_variants() -> None:
     matches = match_bundle_models(BUNDLES_DIR / "candle.yaml", MODELS_DIR)
     assert matches, "candle bundle should expose at least one model profile variant"


### PR DESCRIPTION
## Summary

- pin `cuda-tile==1.6.0rc8` in the TensorRT-LLM bundle's qualified CUDA closure
- prevent the prerelease-enabled image resolver from silently selecting a newer unqualified build
- add focused regression coverage for the exact bundle constraint

## Validation

- `mise run test -- packages/sie_server/tests/config/test_bundle_coverage.py` — 35 passed
- `mise run lint`
- Docker-equivalent CPython 3.12/Linux dependency resolution selected `cuda-tile==1.6.0rc8`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the TensorRT-LLM CUDA 13 bundle to use the pinned `cuda-tile` version `1.6.0rc8`.

- **Tests**
  - Added coverage to verify that the bundle continues to use the required `cuda-tile` version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->