### PR TITLE
fix(tooling): use canonical Rust LLVM component

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ experimental = true
 [tools]
 python = "3.12.12"
 uv = "0.5.31"
-rust = { version = "1.97.0", profile = "default", components = ["rustfmt", "clippy", "llvm-tools-preview"] }
+rust = { version = "1.97.0", profile = "default", components = ["rustfmt", "clippy", "llvm-tools"] }
 "cargo:cargo-deny" = "0.20.2"
 "cargo:cargo-llvm-cov" = "0.8.7"
 node = ["24.12.0", "22.23.2"]

--- a/tools/ci/tests/test_public_tree.py
+++ b/tools/ci/tests/test_public_tree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import tomllib
 from pathlib import Path
 
 from tools.ci import check_public_tree
@@ -54,6 +55,11 @@ def test_bootstrap_uses_root_locks_even_in_ci() -> None:
     assert "XDG_STATE_HOME" not in mise_config
     assert not (REPOSITORY_ROOT / ".npmrc").exists()
     assert not (REPOSITORY_ROOT / "packages/sie_ts_sdk/pnpm-lock.yaml").exists()
+
+
+def test_bootstrap_installs_canonical_rust_components() -> None:
+    mise_config = tomllib.loads((REPOSITORY_ROOT / "mise.toml").read_text())
+    assert mise_config["tools"]["rust"]["components"] == ["rustfmt", "clippy", "llvm-tools"]
 
 
 def test_ci_is_fork_safe_and_actions_are_immutable() -> None:

--- a/tools/mise_tasks/gateway-coverage.bash
+++ b/tools/mise_tasks/gateway-coverage.bash
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-# cargo-llvm-cov needs the `llvm-tools-preview` rustup component, which
+# cargo-llvm-cov needs the canonical `llvm-tools` rustup component, which
 # mise.toml declares alongside the rust toolchain pin so `mise install`
 # provisions it on every dev machine and CI runner.
 #


### PR DESCRIPTION
## Summary

- configure the Rust toolchain with mise's canonical `llvm-tools` component name
- keep the gateway coverage prerequisite documentation aligned
- add a semantic regression test for the required Rust component set

## Validation

- clean bootstrap with isolated Rust and Cargo homes
- post-bootstrap `mise install rust --dry-run-code --verbose` reports Rust 1.97.0 already installed
- rustup reports `llvm-tools-aarch64-apple-darwin` installed
- `pytest -q tools/ci/tests/test_public_tree.py` (`6 passed`)
- Ruff format and lint checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain configuration to use the canonical `llvm-tools` component.
  * Updated coverage setup documentation to reflect the current component name.

* **Tests**
  * Added validation that the Rust environment includes the required `rustfmt`, `clippy`, and `llvm-tools` components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->