### PR TITLE
ci: strengthen development checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,11 @@ jobs:
         with:
           cache: false
       - run: mise run sync
+      - run: mise run openapi
+      - run: >-
+          git diff --exit-code --
+          packages/sie_server/openapi.json
+          packages/sie_gateway/openapi.json
       - run: mise exec -- python tools/check_ipc_types_parity.py
       - run: mise exec -- python tools/check_response_chunk_protocol.py
       - run: tests/parity/run_parity.sh
@@ -157,6 +162,11 @@ jobs:
       - run: mise run helm -- dependencies
       - run: mise run helm -- lint --set payloadStore.enabled=false
       - run: mise run helm -- template --set payloadStore.enabled=false >/dev/null
+      - name: Render public cloud overlays
+        run: |
+          for values in values-aws.yaml values-gke.yaml values-aks.yaml values-ack.yaml; do
+            mise run helm -- template -f "deploy/helm/sie-cluster/${values}" --set payloadStore.enabled=false >/dev/null
+          done
       - run: |
           destination="$(mktemp -d)"
           mise exec -- helm package deploy/helm/sie-cluster --destination "$destination"
@@ -201,8 +211,7 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           cache: false
-      - run: mise run sync
-      - run: mise exec -- uv run --frozen --project . --no-sync python -m tools.ci.cpu_stack_smoke
+      - run: mise run cpu-stack
       - name: Preserve diagnostics
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/cuda13-bundle-image.yml
+++ b/.github/workflows/cuda13-bundle-image.yml
@@ -1,0 +1,37 @@
+name: CUDA 13 bundle image
+
+on:
+  workflow_call:
+    inputs:
+      bundle:
+        required: true
+        type: string
+      image-tag:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility:
+    name: CUDA 13 image compatibility / ${{ inputs.bundle }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: useblacksmith/setup-docker-builder@9309da73a81f66976a6d750572e221508b1e2682 # v1
+      - uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v1
+        with:
+          context: .
+          file: packages/sie_server/Dockerfile.cuda13
+          platforms: linux/amd64
+          build-args: |
+            BUNDLE=${{ inputs.bundle }}
+            SIE_SRC_REV=${{ github.sha }}
+          tags: ${{ inputs.image-tag }}
+          load: true
+          push: false
+      - run: python3 tools/ci/cuda13_image_smoke.py "${{ inputs.bundle }}" "${{ inputs.image-tag }}"

--- a/.github/workflows/cuda13-sglang-cu130.yml
+++ b/.github/workflows/cuda13-sglang-cu130.yml
@@ -1,0 +1,29 @@
+name: CUDA 13 SGLang image compatibility
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cuda13-sglang-cu130.yml
+      - .github/workflows/cuda13-bundle-image.yml
+      - tools/ci/cuda13_image_smoke.py
+      - packages/sie_server/Dockerfile.cuda13
+      - packages/sie_server/bundles/sglang-cu130.yaml
+      - packages/sie_server/models/Qwen__Qwen3.6-27B.yaml
+      - packages/sie_server/models/Qwen__Qwen3.8-27B-FP8.yaml
+      - packages/sie_server/models/google__gemma-4-*.yaml
+      - packages/sie_server/src/sie_server/adapters/sglang/**
+      - packages/sie_server/pyproject.toml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cuda13-sglang-cu130-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/cuda13-bundle-image.yml
+    with:
+      bundle: sglang-cu130
+      image-tag: sie-cuda13-sglang-cu130:pr

--- a/.github/workflows/cuda13-sglang-cu130.yml
+++ b/.github/workflows/cuda13-sglang-cu130.yml
@@ -6,7 +6,18 @@ on:
       - .github/workflows/cuda13-sglang-cu130.yml
       - .github/workflows/cuda13-bundle-image.yml
       - tools/ci/cuda13_image_smoke.py
+      - Cargo.toml
+      - Cargo.lock
+      - packages/sie_audio_prep/**
+      - packages/sie_gateway/**
+      - packages/sie_server_sidecar/**
+      - packages/sie_telemetry/**
+      - packages/sie_sdk/pyproject.toml
+      - packages/sie_sdk/src/**
       - packages/sie_server/Dockerfile.cuda13
+      - packages/sie_server/src/**
+      - packages/sie_server/bundles/**
+      - packages/sie_server/models/**
       - packages/sie_server/bundles/sglang-cu130.yaml
       - packages/sie_server/models/Qwen__Qwen3.6-27B.yaml
       - packages/sie_server/models/Qwen__Qwen3.8-27B-FP8.yaml

--- a/.github/workflows/cuda13-tensorrt-llm.yml
+++ b/.github/workflows/cuda13-tensorrt-llm.yml
@@ -1,0 +1,26 @@
+name: CUDA 13 TensorRT-LLM image compatibility
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cuda13-tensorrt-llm.yml
+      - .github/workflows/cuda13-bundle-image.yml
+      - tools/ci/cuda13_image_smoke.py
+      - packages/sie_server/Dockerfile.cuda13
+      - packages/sie_server/bundles/tensorrt-llm.yaml
+      - packages/sie_server/src/sie_server/adapters/tensorrt_llm/**
+      - packages/sie_server/pyproject.toml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cuda13-tensorrt-llm-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/cuda13-bundle-image.yml
+    with:
+      bundle: tensorrt-llm
+      image-tag: sie-cuda13-tensorrt-llm:pr

--- a/.github/workflows/cuda13-tensorrt-llm.yml
+++ b/.github/workflows/cuda13-tensorrt-llm.yml
@@ -6,7 +6,18 @@ on:
       - .github/workflows/cuda13-tensorrt-llm.yml
       - .github/workflows/cuda13-bundle-image.yml
       - tools/ci/cuda13_image_smoke.py
+      - Cargo.toml
+      - Cargo.lock
+      - packages/sie_audio_prep/**
+      - packages/sie_gateway/**
+      - packages/sie_server_sidecar/**
+      - packages/sie_telemetry/**
+      - packages/sie_sdk/pyproject.toml
+      - packages/sie_sdk/src/**
       - packages/sie_server/Dockerfile.cuda13
+      - packages/sie_server/src/**
+      - packages/sie_server/bundles/**
+      - packages/sie_server/models/**
       - packages/sie_server/bundles/tensorrt-llm.yaml
       - packages/sie_server/src/sie_server/adapters/tensorrt_llm/**
       - packages/sie_server/pyproject.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,28 @@ workflow adds full-workspace harnesses and policy gates described below.
 | HTTP and wire contracts | `mise exec -- python tools/check_ipc_types_parity.py`, `mise exec -- python tools/check_response_chunk_protocol.py`, and `tests/parity/run_parity.sh` |
 | Helm chart | `mise run helm -- dependencies`, `mise run helm -- lint --set payloadStore.enabled=false`, and `mise run helm -- template --set payloadStore.enabled=false` |
 
+### Hosted-CI equivalents
+
+These scoped checks are slower and should be run when the corresponding surface changes.
+
+For the live SDK surface, synchronize all dependencies, build the TypeScript workspace, then run the same live and fake-stack checks as hosted CI:
+
+```bash
+mise run full-sync
+mise run ts -- build
+mise exec -- uv run --frozen --project . --no-sync python tools/ci/live_sdk.py
+mise exec -- uv run --frozen --project . --no-sync pytest -q packages/sie_server/tests/fake_stack/test_sdk_surface.py -m integration
+```
+
+For CPU images and their queue topology, use `mise run cpu-stack`. This requires a local Linux Docker daemon and uses the checked-in fake model, so it does not download model weights.
+
+For Python or npm distribution consumers, build into a fresh temporary output path:
+
+```bash
+mise exec -- uv run --frozen --project . --no-sync python tools/ci/distributions.py build python --directory "$(mktemp -d)/python"
+mise exec -- uv run --frozen --project . --no-sync python tools/ci/distributions.py build npm --directory "$(mktemp -d)/npm"
+```
+
 The standalone Candle worker is outside the root Rust workspace. Validate it
 directly:
 

--- a/tools/ci/cuda13_image_smoke.py
+++ b/tools/ci/cuda13_image_smoke.py
@@ -1,0 +1,129 @@
+"""Validate CUDA 13 image dependency contracts without a GPU driver."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import textwrap
+
+ALLOWED_BUNDLES = ("sglang-cu130", "tensorrt-llm")
+
+COMMON_CHECKS = """
+import importlib.metadata
+import sie_audio_prep
+import sie_sdk
+import sie_server
+import torch
+import transformers
+
+assert torch.__version__.split("+", 1)[0] == "2.11.0", torch.__version__
+assert torch.version.cuda and torch.version.cuda.startswith("13."), torch.version.cuda
+"""
+
+SGLANG_CHECKS = """
+import tvm_ffi
+import xgrammar
+from sie_server.adapters.sglang import cuda13, gemma, generation
+
+expected = {
+    "sglang": "0.5.13",
+    "transformers": "5.8.1",
+    "kernels": "0.14.1",
+    "flashinfer-python": "0.6.12",
+    "xgrammar": "0.2.1",
+    "apache-tvm-ffi": "0.1.9",
+}
+for distribution, version in expected.items():
+    assert importlib.metadata.version(distribution) == version, distribution
+for distribution, upstream in (("sgl-deep-gemm", "0.1.2"), ("sglang-kernel", "0.4.3")):
+    actual_upstream, separator, variant = importlib.metadata.version(distribution).partition("+")
+    assert (actual_upstream, separator, variant) == (upstream, "+", "cu130"), distribution
+assert importlib.metadata.distribution("sglang").files
+"""
+
+TENSORRT_LLM_CHECKS = """
+import hashlib
+import importlib.util
+from pathlib import Path
+
+from sie_server.adapters.tensorrt_llm import _server, compat, generation
+
+expected = {
+    "tensorrt-llm": "1.3.0rc24",
+    "transformers": "5.5.4",
+    "flashinfer-python": "0.6.16",
+    "cuda-tile": "1.6.0rc8",
+    "triton": "3.6.0",
+    "nvidia-cutlass-dsl": "4.5.0",
+    "nvidia-cuda-tileiras": "13.1.80",
+    "nvidia-matmul-heuristics": "0.1.0.27",
+    "cuda-pathfinder": "1.7.0",
+    "nvidia-nccl-cu13": "2.28.9",
+    "flash-attn-4": "4.0.0b11",
+    "torch-c-dlpack-ext": "0.1.3",
+    "xgrammar": "0.1.32",
+    "apache-tvm-ffi": "0.1.6",
+    "mpmath": "1.3.0",
+}
+for distribution, version in expected.items():
+    assert importlib.metadata.version(distribution) == version, distribution
+
+engine = importlib.util.find_spec("tensorrt_llm")
+assert engine is not None and engine.submodule_search_locations
+engine_root = Path(next(iter(engine.submodule_search_locations)))
+guarded_sources = {
+    engine_root / "_torch/models/checkpoints/hf/weight_loader.py": compat.HF_WEIGHT_LOADER_SHA256,
+    engine_root / "_torch/models/modeling_t5.py": compat.MODELING_T5_SHA256,
+}
+for source, expected_sha256 in guarded_sources.items():
+    assert source.is_file(), source
+    assert hashlib.sha256(source.read_bytes()).hexdigest() == expected_sha256, source
+
+from transformers.models.t5 import tokenization_t5
+from transformers import tokenization_utils_tokenizers
+
+compat.verify_exact_transformers_5_sources(tokenization_t5, tokenization_utils_tokenizers)
+"""
+
+
+def validation_script(bundle: str) -> str:
+    if bundle == "sglang-cu130":
+        specific = SGLANG_CHECKS
+    elif bundle == "tensorrt-llm":
+        specific = TENSORRT_LLM_CHECKS
+    else:
+        raise ValueError(f"unsupported CUDA 13 bundle: {bundle}")
+    return textwrap.dedent(COMMON_CHECKS + specific)
+
+
+def docker_commands(bundle: str, image_tag: str) -> list[list[str]]:
+    script = validation_script(bundle)
+    common = [
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        "none",
+        "-e",
+        "HF_HUB_OFFLINE=1",
+        "-e",
+        "TRANSFORMERS_OFFLINE=1",
+    ]
+    return [
+        [*common, "--entrypoint", "python", image_tag, "-c", script],
+        [*common, image_tag, "resolve-deps", "--bundle", bundle, "--models-dir", "/app/models"],
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", choices=ALLOWED_BUNDLES)
+    parser.add_argument("image_tag")
+    args = parser.parse_args()
+    for command in docker_commands(args.bundle, args.image_tag):
+        subprocess.run(command, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/tests/test_cpu_checks.py
+++ b/tools/ci/tests/test_cpu_checks.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 from tools.ci import cpu_stack_smoke, live_sdk, rust_tests
+
+ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_rust_fails_without_nats(monkeypatch):
@@ -83,3 +86,13 @@ def test_cpu_builds_all_six_images_without_publish(monkeypatch):
     assert all(command[:4] == ["mise", "run", "docker", "--"] for command in commands)
     assert all("--push" not in command for command in commands)
     assert [command[command.index("--service") + 1] for command in commands[1:]] == list(cpu_stack_smoke.SERVICES)
+
+
+def test_cpu_stack_task_wraps_one_harness_and_docker_flag_delegates():
+    wrapper = (ROOT / "tools/mise_tasks/cpu-stack.bash").read_text()
+    test_task = (ROOT / "tools/mise_tasks/test.bash").read_text()
+    assert "mise run sync" in wrapper
+    assert "python -m tools.ci.cpu_stack_smoke" in wrapper
+    assert "exec mise run cpu-stack" in test_task
+    assert 'ARGS+=("-m" "docker"' not in test_task
+    assert "test_docker_integration.py" not in test_task

--- a/tools/ci/tests/test_cuda13_image_smoke.py
+++ b/tools/ci/tests/test_cuda13_image_smoke.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from tools.ci import cuda13_image_smoke
+
+
+def test_exact_bundle_allowlist():
+    assert cuda13_image_smoke.ALLOWED_BUNDLES == ("sglang-cu130", "tensorrt-llm")
+
+
+@pytest.mark.parametrize("bundle", cuda13_image_smoke.ALLOWED_BUNDLES)
+def test_commands_are_networkless_offline_and_never_publish(bundle):
+    compile(cuda13_image_smoke.validation_script(bundle), f"<{bundle}-image-check>", "exec")
+    commands = cuda13_image_smoke.docker_commands(bundle, "sie-cuda13-smoke:local")
+    assert len(commands) == 2
+    for command in commands:
+        assert command[:3] == ["docker", "run", "--rm"]
+        assert ["--network", "none"] == command[3:5]
+        assert "HF_HUB_OFFLINE=1" in command
+        assert "TRANSFORMERS_OFFLINE=1" in command
+        assert not {"push", "login"} & set(command)
+    assert commands[1][-5:] == ["resolve-deps", "--bundle", bundle, "--models-dir", "/app/models"]
+
+
+def test_sglang_check_uses_safe_distribution_and_adapter_surfaces():
+    script = cuda13_image_smoke.validation_script("sglang-cu130")
+    assert 'distribution("sglang")' in script
+    assert "import tvm_ffi" in script
+    assert "import xgrammar" in script
+    assert "from sie_server.adapters.sglang import cuda13, gemma, generation" in script
+    assert "import sglang" not in script
+
+
+def test_sglang_native_wheels_require_exact_cu130_local_variants():
+    script = cuda13_image_smoke.validation_script("sglang-cu130")
+    assert '(("sgl-deep-gemm", "0.1.2"), ("sglang-kernel", "0.4.3"))' in script
+    assert '.partition("+")' in script
+    assert '(upstream, "+", "cu130")' in script
+
+
+def test_tensorrt_check_locates_engine_and_verifies_qualified_sources():
+    script = cuda13_image_smoke.validation_script("tensorrt-llm")
+    assert 'find_spec("tensorrt_llm")' in script
+    assert "import tensorrt_llm" not in script
+    assert "HF_WEIGHT_LOADER_SHA256" in script
+    assert "MODELING_T5_SHA256" in script
+    assert "verify_exact_transformers_5_sources" in script
+    assert '"tensorrt-llm": "1.3.0rc24"' in script
+
+
+def test_unknown_bundle_is_rejected_before_docker(monkeypatch):
+    run = Mock()
+    monkeypatch.setattr(cuda13_image_smoke.subprocess, "run", run)
+    with pytest.raises(ValueError, match="unsupported CUDA 13 bundle"):
+        cuda13_image_smoke.docker_commands("unknown", "image:local")
+    run.assert_not_called()

--- a/tools/ci/tests/test_model_test_selection.py
+++ b/tools/ci/tests/test_model_test_selection.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.mise_tasks import model_test_selection
+
+ROOT = Path(__file__).resolve().parents[3]
+MODEL_TEST = ROOT / "packages/sie_server/tests/test_all_models.py"
+
+
+def select(model_id: str) -> list[str]:
+    return model_test_selection.select_node_ids(model_id, MODEL_TEST.read_text(), str(MODEL_TEST))
+
+
+def test_base_bge_m3_selects_only_exact_base_tests():
+    selected = select("BAAI/bge-m3")
+    assert {node_id.rsplit("::", 1)[1] for node_id in selected} == {
+        "test_baai_bge_m3_dense",
+        "test_baai_bge_m3_sparse",
+        "test_baai_bge_m3_multivector",
+    }
+
+
+def test_bge_m3_profile_selects_only_that_exact_profile():
+    selected = select("BAAI/bge-m3:dense")
+    assert selected
+    assert all("bge_m3_dense_profile" in node_id for node_id in selected)
+    assert not set(selected) & set(select("BAAI/bge-m3"))
+
+
+def test_qwen_reranker_selects_every_exact_handwritten_test():
+    selected = select("Qwen/Qwen3-Reranker-0.6B")
+    assert {node_id.rsplit("::", 1)[1] for node_id in selected} == {
+        "test_qwen_qwen3_reranker_0_6b_score",
+        "test_qwen_qwen3_reranker_0_6b_score_in_range",
+        "test_qwen_qwen3_reranker_0_6b_score_with_instruction",
+    }
+
+
+@pytest.mark.parametrize("model_id", ["Qwen/Qwen3-0.6B", "made-up/does-not-exist", "baai/bge-m3"])
+def test_uncovered_unknown_and_wrong_case_ids_select_nothing(model_id):
+    assert select(model_id) == []
+
+
+def test_ambiguous_test_mapping_is_rejected():
+    source = """
+def test_ambiguous():
+    _assert_dense("one/model")
+    _assert_sparse("other/model")
+"""
+    with pytest.raises(ValueError, match="maps to multiple model IDs"):
+        model_test_selection.select_node_ids("one/model", source, "synthetic.py")

--- a/tools/ci/tests/test_required_ci.py
+++ b/tools/ci/tests/test_required_ci.py
@@ -134,10 +134,12 @@ def test_contracts_regenerate_both_openapi_documents_before_exact_diff():
 
 def test_helm_renders_each_cloud_overlay():
     workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
-    commands = "\n".join(step.get("run", "") for step in workflow["jobs"]["helm"]["steps"])
+    commands = [step.get("run", "") for step in workflow["jobs"]["helm"]["steps"]]
+    assert "mise run helm -- template --set payloadStore.enabled=false >/dev/null" in commands
+    overlay_command = next(command for command in commands if "for values in" in command)
     for overlay in ("values-aws.yaml", "values-gke.yaml", "values-aks.yaml", "values-ack.yaml"):
-        assert commands.count(overlay) == 1
-    assert "--set payloadStore.enabled=false" in commands
+        assert overlay_command.count(overlay) == 1
+    assert "--set payloadStore.enabled=false" in overlay_command
 
 
 def test_cpu_lane_uses_cpu_stack_task():
@@ -165,34 +167,46 @@ def test_rust_audits_both_committed_dependency_graphs():
     ] in commands
 
 
+CUDA13_SHARED_PATHS = {
+    ".github/workflows/cuda13-bundle-image.yml",
+    "tools/ci/cuda13_image_smoke.py",
+    "Cargo.toml",
+    "Cargo.lock",
+    "packages/sie_audio_prep/**",
+    "packages/sie_gateway/**",
+    "packages/sie_server_sidecar/**",
+    "packages/sie_telemetry/**",
+    "packages/sie_sdk/pyproject.toml",
+    "packages/sie_sdk/src/**",
+    "packages/sie_server/Dockerfile.cuda13",
+    "packages/sie_server/src/**",
+    "packages/sie_server/bundles/**",
+    "packages/sie_server/models/**",
+    "packages/sie_server/pyproject.toml",
+}
+
 CUDA_CALLERS = {
     "cuda13-sglang-cu130.yml": {
         "bundle": "sglang-cu130",
         "image-tag": "sie-cuda13-sglang-cu130:pr",
-        "paths": {
+        "paths": CUDA13_SHARED_PATHS
+        | {
             ".github/workflows/cuda13-sglang-cu130.yml",
-            ".github/workflows/cuda13-bundle-image.yml",
-            "tools/ci/cuda13_image_smoke.py",
-            "packages/sie_server/Dockerfile.cuda13",
             "packages/sie_server/bundles/sglang-cu130.yaml",
             "packages/sie_server/models/Qwen__Qwen3.6-27B.yaml",
             "packages/sie_server/models/Qwen__Qwen3.8-27B-FP8.yaml",
             "packages/sie_server/models/google__gemma-4-*.yaml",
             "packages/sie_server/src/sie_server/adapters/sglang/**",
-            "packages/sie_server/pyproject.toml",
         },
     },
     "cuda13-tensorrt-llm.yml": {
         "bundle": "tensorrt-llm",
         "image-tag": "sie-cuda13-tensorrt-llm:pr",
-        "paths": {
+        "paths": CUDA13_SHARED_PATHS
+        | {
             ".github/workflows/cuda13-tensorrt-llm.yml",
-            ".github/workflows/cuda13-bundle-image.yml",
-            "tools/ci/cuda13_image_smoke.py",
-            "packages/sie_server/Dockerfile.cuda13",
             "packages/sie_server/bundles/tensorrt-llm.yaml",
             "packages/sie_server/src/sie_server/adapters/tensorrt_llm/**",
-            "packages/sie_server/pyproject.toml",
         },
     },
 }

--- a/tools/ci/tests/test_required_ci.py
+++ b/tools/ci/tests/test_required_ci.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import json
 import os
 import re
@@ -111,6 +112,40 @@ def test_typescript_build_precedes_typecheck():
     assert commands.index("mise run ts -- build") < commands.index("mise run ts -- typecheck")
 
 
+def test_contracts_regenerate_both_openapi_documents_before_exact_diff():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    commands = [step.get("run", "") for step in workflow["jobs"]["contracts"]["steps"]]
+    generation = commands.index("mise run openapi")
+    diff = next(
+        index
+        for index, command in enumerate(commands)
+        if "git diff --exit-code" in command and "packages/sie_server/openapi.json" in command
+    )
+    assert generation < diff
+    assert shlex.split(commands[diff]) == [
+        "git",
+        "diff",
+        "--exit-code",
+        "--",
+        "packages/sie_server/openapi.json",
+        "packages/sie_gateway/openapi.json",
+    ]
+
+
+def test_helm_renders_each_cloud_overlay():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    commands = "\n".join(step.get("run", "") for step in workflow["jobs"]["helm"]["steps"])
+    for overlay in ("values-aws.yaml", "values-gke.yaml", "values-aks.yaml", "values-ack.yaml"):
+        assert commands.count(overlay) == 1
+    assert "--set payloadStore.enabled=false" in commands
+
+
+def test_cpu_lane_uses_cpu_stack_task():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    commands = [step.get("run") for step in workflow["jobs"]["cpu-stack"]["steps"] if "run" in step]
+    assert commands == ["mise run cpu-stack"]
+
+
 def test_rust_audits_both_committed_dependency_graphs():
     workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
     commands = [shlex.split(step.get("run", "")) for step in workflow["jobs"]["rust"]["steps"]]
@@ -128,3 +163,137 @@ def test_rust_audits_both_committed_dependency_graphs():
         "deny.toml",
         "check",
     ] in commands
+
+
+CUDA_CALLERS = {
+    "cuda13-sglang-cu130.yml": {
+        "bundle": "sglang-cu130",
+        "image-tag": "sie-cuda13-sglang-cu130:pr",
+        "paths": {
+            ".github/workflows/cuda13-sglang-cu130.yml",
+            ".github/workflows/cuda13-bundle-image.yml",
+            "tools/ci/cuda13_image_smoke.py",
+            "packages/sie_server/Dockerfile.cuda13",
+            "packages/sie_server/bundles/sglang-cu130.yaml",
+            "packages/sie_server/models/Qwen__Qwen3.6-27B.yaml",
+            "packages/sie_server/models/Qwen__Qwen3.8-27B-FP8.yaml",
+            "packages/sie_server/models/google__gemma-4-*.yaml",
+            "packages/sie_server/src/sie_server/adapters/sglang/**",
+            "packages/sie_server/pyproject.toml",
+        },
+    },
+    "cuda13-tensorrt-llm.yml": {
+        "bundle": "tensorrt-llm",
+        "image-tag": "sie-cuda13-tensorrt-llm:pr",
+        "paths": {
+            ".github/workflows/cuda13-tensorrt-llm.yml",
+            ".github/workflows/cuda13-bundle-image.yml",
+            "tools/ci/cuda13_image_smoke.py",
+            "packages/sie_server/Dockerfile.cuda13",
+            "packages/sie_server/bundles/tensorrt-llm.yaml",
+            "packages/sie_server/src/sie_server/adapters/tensorrt_llm/**",
+            "packages/sie_server/pyproject.toml",
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(("filename", "expected"), CUDA_CALLERS.items())
+def test_cuda13_callers_have_exact_inputs_and_narrow_paths(filename, expected):
+    workflow = yaml.safe_load((ROOT / ".github/workflows" / filename).read_text())
+    triggers = workflow.get("on", workflow.get(True))
+    assert set(triggers) == {"pull_request"}
+    assert set(triggers["pull_request"]["paths"]) == expected["paths"]
+    assert workflow["permissions"] == {"contents": "read"}
+    assert set(workflow["jobs"]) == {"compatibility"}
+    job = workflow["jobs"]["compatibility"]
+    assert job["uses"] == "./.github/workflows/cuda13-bundle-image.yml"
+    assert job["with"] == {"bundle": expected["bundle"], "image-tag": expected["image-tag"]}
+
+
+def test_sglang_cuda13_model_configs_are_covered_by_caller_paths():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/cuda13-sglang-cu130.yml").read_text())
+    triggers = workflow.get("on", workflow.get(True))
+    model_patterns = [
+        path for path in triggers["pull_request"]["paths"] if path.startswith("packages/sie_server/models/")
+    ]
+    adapter_modules = ("sie_server.adapters.sglang.cuda13", "sie_server.adapters.sglang.gemma")
+    referenced_models = {
+        str(path.relative_to(ROOT))
+        for path in (ROOT / "packages/sie_server/models").glob("*.yaml")
+        if any(module in path.read_text() for module in adapter_modules)
+    }
+    assert referenced_models
+    assert all(any(fnmatch.fnmatch(model, pattern) for pattern in model_patterns) for model in referenced_models)
+
+
+@pytest.mark.parametrize(
+    ("filename", "group"),
+    [
+        (
+            "cuda13-sglang-cu130.yml",
+            "cuda13-sglang-cu130-${{ github.event.pull_request.number || github.ref }}",
+        ),
+        (
+            "cuda13-tensorrt-llm.yml",
+            "cuda13-tensorrt-llm-${{ github.event.pull_request.number || github.ref }}",
+        ),
+    ],
+)
+def test_cuda13_callers_cancel_superseded_pr_runs(filename, group):
+    workflow = yaml.safe_load((ROOT / ".github/workflows" / filename).read_text())
+    assert workflow["concurrency"] == {"group": group, "cancel-in-progress": True}
+
+
+def test_cuda13_reusable_workflow_is_read_only_pinned_and_build_only():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/cuda13-bundle-image.yml").read_text())
+    triggers = workflow.get("on", workflow.get(True))
+    inputs = triggers["workflow_call"]["inputs"]
+    assert inputs == {
+        "bundle": {"required": True, "type": "string"},
+        "image-tag": {"required": True, "type": "string"},
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    job = workflow["jobs"]["compatibility"]
+    assert job["runs-on"] == "blacksmith-8vcpu-ubuntu-2404"
+    assert job["timeout-minutes"] == 90
+    assert [step.get("uses") for step in job["steps"] if "uses" in step] == [
+        "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd",
+        "useblacksmith/setup-docker-builder@9309da73a81f66976a6d750572e221508b1e2682",
+        "useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850",
+    ]
+    build = next(step for step in job["steps"] if step.get("uses", "").startswith("useblacksmith/build-push-action@"))
+    assert build["with"] == {
+        "context": ".",
+        "file": "packages/sie_server/Dockerfile.cuda13",
+        "platforms": "linux/amd64",
+        "build-args": "BUNDLE=${{ inputs.bundle }}\nSIE_SRC_REV=${{ github.sha }}\n",
+        "tags": "${{ inputs.image-tag }}",
+        "load": True,
+        "push": False,
+    }
+    assert job["steps"][-1]["run"] == (
+        'python3 tools/ci/cuda13_image_smoke.py "${{ inputs.bundle }}" "${{ inputs.image-tag }}"'
+    )
+
+
+def test_cuda13_workflows_have_no_privileged_or_unrelated_behavior():
+    for filename in ("cuda13-bundle-image.yml", *CUDA_CALLERS):
+        text = (ROOT / ".github/workflows" / filename).read_text()
+        lowered = text.lower()
+        for forbidden in (
+            "pull_request_target",
+            "secrets.",
+            "docker login",
+            "environment:",
+            "docker push",
+            "benchmark",
+            "quality",
+            "load-test",
+        ):
+            assert forbidden not in lowered
+        workflow = yaml.safe_load(text)
+        for job in workflow["jobs"].values():
+            uses = [job.get("uses", ""), *(step.get("uses", "") for step in job.get("steps", []))]
+            for action in filter(None, uses):
+                assert action.startswith("./") or re.fullmatch(r"[\w/-]+@[a-f0-9]{40}", action)

--- a/tools/mise_tasks/cpu-stack.bash
+++ b/tools/mise_tasks/cpu-stack.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Build and exercise the full CPU-container stack"
+
+set -euo pipefail
+
+mise run sync
+mise exec -- uv run --frozen --project . --no-sync python -m tools.ci.cpu_stack_smoke

--- a/tools/mise_tasks/model_test_selection.py
+++ b/tools/mise_tasks/model_test_selection.py
@@ -1,0 +1,68 @@
+"""Select handwritten model tests by their exact model-ID literals."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+MODEL_TEST_PATH = Path("packages/sie_server/tests/test_all_models.py")
+MODEL_CALLS = {
+    "_get_adapter",
+    "_assert_dense",
+    "_assert_dense_image",
+    "_assert_sparse",
+    "_assert_multivector",
+    "_assert_multivector_image",
+    "_assert_score",
+    "_assert_extract",
+}
+
+
+def model_id_literals(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    model_ids: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = node.func.id if isinstance(node.func, ast.Name) else None
+        first_argument = node.args[0]
+        if name in MODEL_CALLS and isinstance(first_argument, ast.Constant) and isinstance(first_argument.value, str):
+            model_ids.add(first_argument.value)
+    return model_ids
+
+
+def select_node_ids(model_id: str, source: str, path: str = str(MODEL_TEST_PATH)) -> list[str]:
+    tree = ast.parse(source, filename=path)
+    selected: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.name.startswith("test_"):
+            continue
+        model_ids = model_id_literals(node)
+        if len(model_ids) > 1:
+            rendered = ", ".join(sorted(repr(value) for value in model_ids))
+            raise ValueError(f"{path}::{node.name} maps to multiple model IDs: {rendered}")
+        if model_ids == {model_id}:
+            selected.append(f"{path}::{node.name}")
+    return selected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model_id")
+    parser.add_argument("--test-file", type=Path, default=MODEL_TEST_PATH)
+    args = parser.parse_args()
+    try:
+        selected = select_node_ids(args.model_id, args.test_file.read_text(), str(args.test_file))
+    except (OSError, SyntaxError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    if not selected:
+        print(f"ERROR: no handwritten model tests map exactly to {args.model_id!r}", file=sys.stderr)
+        return 1
+    print("\n".join(selected))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mise_tasks/test.bash
+++ b/tools/mise_tasks/test.bash
@@ -2,7 +2,7 @@
 #MISE description="Run tests"
 #USAGE flag "-c --coverage" help="Run with coverage report"
 #USAGE flag "-i --integration" help="Run integration tests (requires running server)"
-#USAGE flag "-d --docker" help="Run Docker integration tests (slow, builds Docker image)"
+#USAGE flag "-d --docker" help="Run the full CPU-container stack (slow, requires local Linux Docker)"
 #USAGE flag "-l --collect-only" help="Only collect and list test names, don't run them"
 #USAGE flag "-k --filter <filter>" help="Filter tests by name expression (passed to pytest -k)"
 #USAGE flag "-m --model <model>" help="Run model tests for a model ID (e.g. BAAI/bge-m3) or 'all' for all models"
@@ -11,6 +11,16 @@
 set -euo pipefail
 
 ARGS=()
+
+if [[ "${usage_docker:-}" == "true" ]]; then
+    if [[ "${usage_collect_only:-}" == "true" || "${usage_coverage:-}" == "true" || \
+          "${usage_integration:-}" == "true" || -n "${usage_filter:-}" || \
+          -n "${usage_model:-}" || -n "${usage_path:-}" ]]; then
+        echo "ERROR: --docker delegates to 'mise run cpu-stack' and cannot be combined with pytest selectors." >&2
+        exit 1
+    fi
+    exec mise run cpu-stack
+fi
 
 if [[ "${usage_collect_only:-}" == "true" ]]; then
     ARGS+=("--collect-only" "-q")
@@ -26,9 +36,7 @@ if [[ -n "${usage_filter:-}" ]]; then
     ARGS+=("-k" "${usage_filter}")
 fi
 
-if [[ "${usage_docker:-}" == "true" ]]; then
-    ARGS+=("-m" "docker" "-s" "-o" "log_cli=true" "-o" "log_cli_level=INFO")
-elif [[ "${usage_integration:-}" == "true" ]]; then
+if [[ "${usage_integration:-}" == "true" ]]; then
     ARGS+=("-m" "integration" "-s" "-o" "log_cli=true" "-o" "log_cli_level=INFO")
 fi
 
@@ -51,23 +59,16 @@ echo "## Syncing public workspace"
 mise exec -- uv sync --frozen --project . --all-packages --no-install-package sie-audio-prep
 
 if [[ -n "${usage_model:-}" ]]; then
-    ARGS+=("packages/sie_server/tests/test_all_models.py" "-m" "model")
-    if [[ "${usage_model}" != "all" ]]; then
-        sanitized=$(echo "${usage_model}" | sed 's/[^a-zA-Z0-9]/_/g' | tr '[:upper:]' '[:lower:]')
-        # Test names may not include the full model ID; trim from right until matches exist.
-        all_tests=$(mise exec -- uv run --frozen --project . --no-sync pytest -c pyproject.toml \
-            packages/sie_server/tests/test_all_models.py -m model --collect-only -q 2>/dev/null || true)
-        while [[ -n "$sanitized" ]]; do
-            if echo "$all_tests" | grep -qi "$sanitized"; then
-                break
-            fi
-            sanitized="${sanitized%_*}"
-        done
-        if [[ -n "$sanitized" ]]; then
-            ARGS+=("-k" "${sanitized}")
-        else
-            echo "WARNING: no tests found matching model '${usage_model}'" >&2
-        fi
+    ARGS+=("-m" "model")
+    if [[ "${usage_model}" == "all" ]]; then
+        ARGS+=("packages/sie_server/tests/test_all_models.py")
+    else
+        selected_tests=$(mise exec -- python tools/mise_tasks/model_test_selection.py "${usage_model}")
+        model_node_ids=()
+        while IFS= read -r node_id; do
+            model_node_ids+=("${node_id}")
+        done <<<"${selected_tests}"
+        ARGS+=("${model_node_ids[@]}")
     fi
 fi
 


### PR DESCRIPTION
## Summary

- verify both committed OpenAPI specifications and render every shipped provider overlay in CI
- make model-test selection exact and fail closed, with one shared `mise run cpu-stack` entry point for the full CPU container topology
- add narrowly triggered CUDA 13 SGLang and TensorRT-LLM image compatibility builds on Blacksmith with read-only permissions, no credentials, and no publication
- document the scoped local equivalents for live SDK, CPU-stack, and distribution checks

## Validation

- complete `tools/ci/tests` suite: 311 passed
- focused workflow, CPU, CUDA, and model-selection tests: 133 passed
- `mise run cpu-stack` passed twice, including all six images and the gateway/config/worker/sidecar/MCP/Rust IPC path
- OpenAPI regeneration, Helm lint plus AWS/GKE/AKS/ACK renders, Ruff, actionlint, shell syntax, and public-tree checks passed

The two multi-gigabyte CUDA image builds are intentionally executed by the path-triggered PR checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - CI now verifies regenerated API specifications, renders cloud-specific Helm configurations, and uses a unified CPU stack validation task.
  - Added automated CUDA 13 compatibility checks for SGLang and TensorRT-LLM images, including offline dependency and smoke-test validation.
  - Improved model-based test selection to run only applicable tests and reject ambiguous mappings.
  - Expanded CI coverage for relevant CUDA image changes.

- **Documentation**
  - Added guidance for reproducing hosted CI checks locally, including SDK, CPU stack, and package build validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->