### PR TITLE
fix(config): route Qwen3.8 grammar requests without speculation

### DIFF
--- a/packages/sie_server/models/Qwen__Qwen3.8-27B-FP8.yaml
+++ b/packages/sie_server/models/Qwen__Qwen3.8-27B-FP8.yaml
@@ -20,6 +20,7 @@ tasks:
     # exact-hardware profiles whose admission and launch shapes are smoke-tested.
     context_length: 8192
     max_output_tokens: 4096
+    grammar_profile: no-spec
     capabilities:
       grammar: ["json_schema", "regex"]
       streaming: true
@@ -79,6 +80,9 @@ profiles:
           presence_penalty: 1.5
         stop_tokens:
           - "<|im_end|>"
+
+  no-spec:
+    extends: default
 
   # H100-80GB: one native-window admission with in-checkpoint MTP. FA3 plus
   # BF16 GDN state is the measured SM90 batch-one winner. Profile-scoped

--- a/packages/sie_server/tests/config/test_qwen38_generation_profiles.py
+++ b/packages/sie_server/tests/config/test_qwen38_generation_profiles.py
@@ -42,6 +42,7 @@ def test_qwen38_uses_the_pinned_official_fp8_checkpoint() -> None:
     assert config.tasks.generate.chat_template_kwargs == {"enable_thinking": False}
     assert set(config.profiles) == {
         "default",
+        "no-spec",
         "h100-256k",
         "h100-256k-no-spec",
         "h200-256k",
@@ -54,7 +55,11 @@ def test_qwen38_uses_the_pinned_official_fp8_checkpoint() -> None:
 def test_qwen38_default_is_a_conservative_non_speculative_route() -> None:
     config = load_model_config(_MODEL_PATH)
     default = config.resolve_profile("default")
+    grammar = config.resolve_profile("no-spec")
 
+    assert config.tasks.generate is not None
+    assert config.tasks.generate.grammar_profile == "no-spec"
+    assert grammar == default
     assert default.adapter_path == _ADAPTER
     assert default.max_batch_tokens == 16384
     assert default.kv_budget_tokens == 8192


### PR DESCRIPTION
## Summary

- route Qwen3.8 grammar-constrained requests through an explicit `no-spec` profile
- make that profile inherit the existing conservative default route
- assert the profile is present, selected by the generation task, and resolves exactly to `default`

## Validation

- focused Qwen3.8 profile tests: 5 passed
- grammar-profile and inheritance tests: 14 passed
- repository lint and `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `no-spec` generation profile for the Qwen3.8 model.
  - The default generation task now uses the `no-spec` profile, with settings matching the existing default profile.

- **Tests**
  - Added coverage verifying the new profile and its use by the default generation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->