### PR TITLE
ci: notify sie-web when a release is published

### DIFF
--- a/.github/workflows/notify-sie-web-release.yml
+++ b/.github/workflows/notify-sie-web-release.yml
@@ -1,0 +1,80 @@
+name: Notify sie-web (Release published)
+
+# Fires two repository_dispatch events at superlinked/sie-web whenever a
+# GitHub Release is published here, so the docs site regenerates its
+# release-notes page (sync-release-notes.yml) and bumps the SIE version
+# pinned in the deployment guides (sync-deployment-versions.yml).
+#
+# These dispatches used to be steps inside the internal release/sync
+# workflows and were dropped with the publication rework on 2026-08-18; the
+# docs then sat at v0.7.1 while v0.7.2 and v0.7.3 shipped. Keying off the
+# Release event of this repository keeps the notification independent of how
+# the release is produced. sie-web also polls the latest release daily as a
+# fallback, so a missed event self-heals within a day.
+#
+# Same GitHub App as dispatch-docs-sync.yml; repository_dispatch needs
+# contents:write on the target repo. The default GITHUB_TOKEN cannot dispatch
+# events into another repository.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to announce, e.g. v0.7.3'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    # Pre-releases never reach the docs; sie-web filters them anyway.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release version
+        id: version
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag_name }}
+        run: |
+          set -euo pipefail
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          VERSION="${TAG#v}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::tag '$TAG' is not a release semver tag (vX.Y.Z)"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Announcing release $TAG to sie-web"
+
+      - name: Mint token for sie-web (dispatch)
+        id: sw-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: superlinked
+          repositories: sie-web
+          permission-contents: write
+          permission-metadata: read
+
+      - name: Dispatch release-notes-updated to sie-web
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.sw-token.outputs.token }}
+          repository: superlinked/sie-web
+          event-type: release-notes-updated
+          client-payload: '{"tag": "${{ steps.version.outputs.tag }}", "version": "${{ steps.version.outputs.version }}"}'
+
+      - name: Dispatch deployment-versions-updated to sie-web
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.sw-token.outputs.token }}
+          repository: superlinked/sie-web
+          event-type: deployment-versions-updated
+          client-payload: '{"tag": "${{ steps.version.outputs.tag }}", "version": "${{ steps.version.outputs.version }}"}'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/notify-sie-web-release.yml`: on every published (non-prerelease) GitHub Release it sends two `repository_dispatch` events to `superlinked/sie-web`, `release-notes-updated` and `deployment-versions-updated`, carrying `{tag, version}`.
- Those dispatches used to be steps in the internal release/sync workflows and were removed on 2026-08-18 (sie-internal deea5af1d). Since then the docs site stayed at v0.7.1 while v0.7.2 and v0.7.3 shipped, and the deployment guides kept pinning 0.6.26.
- Keying off this repository's Release event keeps the notification independent of how the release is produced. Releases are created with the release account's token, not `GITHUB_TOKEN`, so the event triggers workflows.
- Uses the same sie-web-sync-bot App and permission set as `dispatch-docs-sync.yml`. A `workflow_dispatch` input (`tag_name`) allows a manual backfill.

## Why here and not sie-internal

sie-internal `AGENTS.md` routes public source and release-automation changes to this repository, and this repository already holds `SYNC_APP_ID` / `SYNC_APP_PRIVATE_KEY`.

## Companion change

superlinked/sie-web PR "docs: sync docs to SIE v0.7.3 and make the release sync self-healing" adds a daily scheduled fallback on the receiving workflows, so a missed event self-heals within a day.

## Test plan

- [x] `actionlint` on the new workflow passes locally.
- [ ] After merge: run the workflow manually with `tag_name = v0.7.3` and confirm two runs start in sie-web (`Sync release notes from sie-internal`, `Sync deployment version from sie-internal`) and each opens or updates its bot PR.
- [ ] On the next real release: confirm the same two sie-web runs appear without manual action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated announcements for published stable releases.
  - Release details and deployment version updates are now shared automatically with the web application.
  - Manual triggering is supported when needed.
  - Prerelease versions are excluded from automatic release announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->