### PR TITLE
Fix/overflow policy validation

### DIFF
--- a/packages/sie_server/src/sie_server/api/options.py
+++ b/packages/sie_server/src/sie_server/api/options.py
@@ -54,8 +54,7 @@ def resolve_runtime_options_with_profile(
 
     overflow_policy = merged.get("overflow_policy")
     if overflow_policy is not None and (
-        not isinstance(overflow_policy, str)
-        or overflow_policy not in VALID_OVERFLOW_POLICIES
+        not isinstance(overflow_policy, str) or overflow_policy not in VALID_OVERFLOW_POLICIES
     ):
         span.set_attribute("error", "invalid_overflow_policy")
         raise HTTPException(

--- a/packages/sie_server/src/sie_server/api/options.py
+++ b/packages/sie_server/src/sie_server/api/options.py
@@ -53,7 +53,10 @@ def resolve_runtime_options_with_profile(
         ) from e
 
     overflow_policy = merged.get("overflow_policy")
-    if overflow_policy is not None and overflow_policy not in VALID_OVERFLOW_POLICIES:
+    if overflow_policy is not None and (
+        not isinstance(overflow_policy, str)
+        or overflow_policy not in VALID_OVERFLOW_POLICIES
+    ):
         span.set_attribute("error", "invalid_overflow_policy")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/packages/sie_server/tests/api/test_option.py
+++ b/packages/sie_server/tests/api/test_option.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sie_server.api.options import resolve_runtime_options_with_profile
+from sie_server.config.model import EmbeddingDim, EncodeTask, ModelConfig, ProfileConfig, Tasks
+
+
+def _make_config() -> ModelConfig:
+    return ModelConfig(
+        sie_id="test",
+        hf_id="org/test",
+        tasks=Tasks(encode=EncodeTask(dense=EmbeddingDim(dim=8))),
+        profiles={
+            "default": ProfileConfig(
+                adapter_path="sie_server.adapters.base:ModelAdapter",
+                max_batch_tokens=8,
+            )
+        },
+    )
+
+
+def test_invalid_overflow_policy_type_returns_400() -> None:
+    span = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_runtime_options_with_profile(
+            _make_config(),
+            {"overflow_policy": ["truncate_text"]},
+            span,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "INVALID_INPUT"


### PR DESCRIPTION
## Fixes

`File path Changed` -> packages/sie_server/src/sie_server/api/options.py

I fixed an issue with `overflow_policy` validation.
If an invalid type such as a list or dictionary was passed as `overflow_policy`, the server could raise a `TypeError` while checking the value against the allowed policies. This resulted in a 500 error even though the problem was with the request itself.

The validation now checks that `overflow_policy` is a string before checking whether it is one of the supported values.

For example, passing:

```json
{
  "overflow_policy": ["truncate_text"]
}
```

will now be handled as an invalid request and return the existing 400 INVALID_INPUT response instead of causing a 500 error.

Valid `overflow_policy` values continue to behave exactly as before. No inference behaviour was changed.

## Testing
```text
mise run test
mise run lint
mise run typecheck
git diff --check
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for overflow policy settings by rejecting non-text values and preserving validation for supported options.
  - Invalid overflow policy input now returns a clear HTTP 400 error instead of being processed as a valid configuration.
  - Existing supported overflow policy values continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->