### PR TITLE
fix: preserve grammar-safe generation defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: >-
           mise exec -- uv run --frozen --project . pytest -q
@@ -44,6 +45,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
           install: false
       - run: bash tools/ci/fresh_bootstrap.bash
@@ -58,6 +60,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise exec -- uv lock --check --project .
       - run: mise run sync
@@ -86,6 +89,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise exec -- pnpm install --frozen-lockfile
       - run: mise run ts -- build
@@ -103,6 +107,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise run sync
       - run: mise run rust-fmt -- --check
@@ -137,6 +142,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise run sync
       - run: mise run openapi
@@ -158,6 +164,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise run helm -- dependencies
       - run: mise run helm -- lint --set payloadStore.enabled=false
@@ -182,6 +189,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise run sync
       - run: mise exec -- pnpm install --frozen-lockfile
@@ -210,6 +218,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           cache: false
       - run: mise run cpu-stack
       - name: Preserve diagnostics

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -31,6 +31,8 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - id: resolve
         name: Validate source closure and coordinated versions
         env:
@@ -60,6 +62,8 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - id: restore
         name: Reuse an already retained original-run image on retry
@@ -149,6 +153,8 @@ jobs:
           python3 tools/ci/release_guard.py publish --source-ref "$RELEASE_SHA"
           --version "$RELEASE_VERSION" --tag-name "$RELEASE_TAG"
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -183,6 +189,8 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - id: restore
         name: Reuse an already retained original-run image on retry
@@ -273,6 +281,8 @@ jobs:
           python3 tools/ci/release_guard.py publish --source-ref "$RELEASE_SHA"
           --version "$RELEASE_VERSION" --tag-name "$RELEASE_TAG"
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -314,6 +324,8 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -377,6 +389,8 @@ jobs:
           python3 tools/ci/release_guard.py publish --source-ref "$RELEASE_SHA"
           --version "$RELEASE_VERSION" --tag-name "$RELEASE_TAG"
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -29,6 +29,8 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - name: Validate, render, and retain the exact chart
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -92,6 +94,8 @@ jobs:
           name: helm-sie-cluster-${{ inputs.version }}
           path: artifact
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -29,6 +29,8 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: docker-service-sie-server-sidecar-${{ inputs.version }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -30,6 +30,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           install_args: python uv node pnpm
       - name: Validate source and optional release identity
         env:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -30,6 +30,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
+          version: 2026.5.5
           install_args: python uv
       - name: Validate source and optional release identity
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
           manifest-file: .release-please-manifest.json
           skip-github-release: ${{ steps.seed.outputs.at_seed }}
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2026.5.5
         if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
       - name: Refresh coupled locks on the release pull request
         if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'

--- a/packages/sie_gateway/src/state/model_registry.rs
+++ b/packages/sie_gateway/src/state/model_registry.rs
@@ -1193,17 +1193,18 @@ impl ModelRegistry {
     /// Resolve the dispatch model id for a grammar-constrained request.
     ///
     /// When a model declares ``tasks.generate.grammar_profile`` (surfaced as
-    /// ``ModelInfoExtras::grammar_profile``), grammar requests must run on the
-    /// ``{base}:{grammar_profile}`` profile variant rather than a speculative
-    /// one — NEXTN/MTP speculative decoding bypasses SGLang's Outlines grammar
+    /// ``ModelInfoExtras::grammar_profile``), incompatible profiles route to
+    /// ``{base}:{grammar_profile}`` rather than a speculative profile —
+    /// NEXTN/MTP speculative decoding bypasses SGLang's Outlines grammar
     /// FSM. An explicit variant may declare a profile-scoped grammar fallback
     /// that preserves its context/hardware/thinking launch shape while
-    /// disabling speculation. A variant that directly inherits the model-wide
-    /// grammar profile and is already safe remains selected.
+    /// disabling speculation. A compatible default profile, or a safe variant
+    /// that directly inherits the model-wide grammar profile, remains selected.
     ///
     /// The routing target is resolved off the request's *base* model, so the
-    /// rewrite fires regardless of which id the caller named:
-    /// - base id (``Qwen/Qwen3.5-4B``)            → ``…:no-spec``
+    /// rewrite applies to incompatible defaults and explicit variants:
+    /// - incompatible base id (``org/grammar-model``) → ``…:no-spec``
+    /// - compatible base id                      → ``Keep``
     /// - sibling variant (``…:a100-40gb``, NEXTN) → ``…:no-spec``
     /// - scoped variant (``…:h200-256k``)         → ``…:h200-256k-no-spec``
     /// - target variant (``…:no-spec``)           → ``Keep`` (already safe)
@@ -1221,6 +1222,13 @@ impl ModelRegistry {
         let Some((base, profile)) = Self::base_grammar_profile(&snap, model) else {
             return GrammarRoute::Keep;
         };
+        if Self::canonical_model_name(&snap, model).as_deref() == Some(base.as_str())
+            && snap.models.get(&base).is_some_and(|entry| {
+                Self::profile_is_grammar_compatible(entry, "default", &profile)
+            })
+        {
+            return GrammarRoute::Keep;
+        }
         let target = format!("{base}:{profile}");
         // The request already names the grammar-safe variant (compare canonical
         // ids so a differently-cased ``…:NO-SPEC`` is still recognised).
@@ -2802,6 +2810,129 @@ mod tests {
             registry.grammar_route_variant("org/scoped-only:safe"),
             GrammarRoute::Keep
         );
+    }
+
+    #[test]
+    fn test_grammar_route_variant_default_profile() {
+        let config: ModelConfig = serde_yaml::from_str(
+            r#"
+name: org/grammar-model
+tasks:
+  generate:
+    grammar_profile: safe
+profiles:
+  default:
+    adapter_path: sie_server.adapters.sglang.generation:SGLangGenerationAdapter
+    adapter_options:
+      loadtime: {grammar_backend: outlines, speculative: {enabled: false}}
+  safe:
+    adapter_path: sie_server.adapters.sglang.generation:SGLangGenerationAdapter
+    adapter_options:
+      loadtime: {grammar_backend: outlines, speculative: {enabled: false}}
+  speculative:
+    adapter_path: sie_server.adapters.sglang.generation:SGLangGenerationAdapter
+    adapter_options:
+      loadtime: {grammar_backend: outlines, speculative: {enabled: true}}
+"#,
+        )
+        .unwrap();
+        let default = config.profiles["default"].clone();
+        let mut cases = vec![("compatible", default.clone(), true)];
+        for (name, field, value, compatible) in [
+            (
+                "fp8",
+                "extra_launch_args",
+                serde_json::json!(["--quantization", "fp8"]),
+                true,
+            ),
+            (
+                "speculation-enabled",
+                "speculative",
+                serde_json::json!({"enabled": true}),
+                false,
+            ),
+            (
+                "speculation-absent",
+                "speculative",
+                serde_json::Value::Null,
+                false,
+            ),
+            (
+                "speculation-malformed",
+                "speculative",
+                serde_json::json!({"enabled": "false"}),
+                false,
+            ),
+            (
+                "backend-mismatch",
+                "grammar_backend",
+                serde_json::json!("xgrammar"),
+                false,
+            ),
+            (
+                "raw-grammar-override",
+                "extra_launch_args",
+                serde_json::json!(["--grammar-backend", "xgrammar"]),
+                false,
+            ),
+            (
+                "raw-speculative-override",
+                "extra_launch_args",
+                serde_json::json!(["--speculative-algo", "NEXTN"]),
+                false,
+            ),
+        ] {
+            let mut profile = default.clone();
+            let loadtime = profile.adapter_options.as_mut().unwrap()["loadtime"]
+                .as_object_mut()
+                .unwrap();
+            if value.is_null() {
+                loadtime.remove(field);
+            } else {
+                loadtime.insert(field.to_string(), value);
+            }
+            cases.push((name, profile, compatible));
+        }
+        let mut different_adapter = default;
+        different_adapter.adapter_path =
+            Some("sie_server.adapters.sentence_transformer:Adapter".to_string());
+        cases.push(("adapter-mismatch", different_adapter, false));
+
+        let (_dir, bundles_dir, models_dir) = create_test_dirs();
+        fs::write(
+            bundles_dir.join("default.yaml"),
+            "name: default\npriority: 10\nadapters:\n  - sie_server.adapters.sglang.generation\n  - sie_server.adapters.sentence_transformer\n",
+        )
+        .unwrap();
+        for (name, profile, compatible) in cases {
+            let registry = ModelRegistry::new(&bundles_dir, &models_dir, true);
+            let mut config = config.clone();
+            config.profiles.insert("default".to_string(), profile);
+            registry.add_model_config(config).unwrap();
+            let fallback = GrammarRoute::Rewrite("org/grammar-model:safe".to_string());
+            let expected = if compatible {
+                GrammarRoute::Keep
+            } else {
+                fallback.clone()
+            };
+            for model in ["org/grammar-model", "ORG/GRAMMAR-MODEL"] {
+                assert_eq!(
+                    registry.grammar_route_variant(model),
+                    expected,
+                    "{name}: {model}"
+                );
+            }
+            assert_eq!(
+                registry.grammar_route_variant("org/grammar-model:speculative"),
+                fallback,
+                "{name}: speculative sibling",
+            );
+            assert_eq!(
+                registry.grammar_route_variant("org/grammar-model:safe"),
+                GrammarRoute::Keep,
+                "{name}: safe target",
+            );
+        }
     }
 
     #[test]

--- a/packages/sie_gateway/src/state/model_registry.rs
+++ b/packages/sie_gateway/src/state/model_registry.rs
@@ -1351,13 +1351,28 @@ impl ModelRegistry {
             Self::profile_loadtime_value(profile, "speculative")
                 .and_then(|value| value.get("enabled")),
             Some(serde_json::Value::Bool(false))
-        )
+        ) && Self::profile_has_no_raw_speculative_overrides(profile)
     }
 
     fn profile_does_not_enable_speculation(profile: &CanonicalProfile) -> bool {
-        match Self::profile_loadtime_value(profile, "speculative") {
+        let typed_safe = match Self::profile_loadtime_value(profile, "speculative") {
             None => true,
             Some(value) => matches!(value.get("enabled"), Some(serde_json::Value::Bool(false))),
+        };
+        typed_safe && Self::profile_has_no_raw_speculative_overrides(profile)
+    }
+
+    fn profile_has_no_raw_speculative_overrides(profile: &CanonicalProfile) -> bool {
+        match Self::profile_loadtime_value(profile, "extra_launch_args") {
+            None | Some(serde_json::Value::Null) => true,
+            Some(serde_json::Value::Array(args)) => args.iter().all(|arg| {
+                arg.as_str().is_some_and(|arg| {
+                    let flag = arg.split_once('=').map_or(arg, |(flag, _)| flag);
+                    !flag.starts_with("--speculative-")
+                        && !matches!(flag, "--enable-multi-layer-eagle" | "--config")
+                })
+            }),
+            _ => false,
         }
     }
 
@@ -2933,6 +2948,135 @@ profiles:
                 "{name}: safe target",
             );
         }
+    }
+
+    #[test]
+    fn test_grammar_profiles_reject_matching_raw_speculative_overrides() {
+        let config: ModelConfig = serde_yaml::from_str(
+            r#"
+name: org/grammar-model
+profiles:
+  default:
+    adapter_path: sie_server.adapters.sglang.generation:SGLangGenerationAdapter
+    adapter_options:
+      loadtime: {grammar_backend: outlines, speculative: {enabled: false}}
+  safe:
+    extends: default
+"#,
+        )
+        .unwrap();
+        for args in [
+            serde_json::json!(["--speculative-algorithm", "NEXTN"]),
+            serde_json::json!(["--speculative-algorithm=NEXTN"]),
+            serde_json::json!(["--speculative-algo", "NEXTN"]),
+            serde_json::json!(["--speculative-algo=NEXTN"]),
+            serde_json::json!(["--speculative-draft-model-path", "org/draft"]),
+            serde_json::json!(["--speculative-num-steps", "5"]),
+            serde_json::json!(["--enable-multi-layer-eagle"]),
+            serde_json::json!(["--config", "server.yaml"]),
+            serde_json::json!(["--config=server.yaml"]),
+        ] {
+            let mut config = config.clone();
+            config
+                .profiles
+                .get_mut("default")
+                .unwrap()
+                .adapter_options
+                .as_mut()
+                .unwrap()["loadtime"]["extra_launch_args"] = args.clone();
+            let entry = ModelRegistry::model_entry_from_config(&config).unwrap();
+            assert!(
+                !ModelRegistry::profile_is_grammar_compatible(&entry, "default", "safe"),
+                "matching launch overrides must not establish grammar compatibility: {args}"
+            );
+            config.tasks =
+                Some(serde_yaml::from_str("generate:\n  grammar_profile: safe\n").unwrap());
+            let error = ModelRegistry::model_entry_from_config(&config).unwrap_err();
+            assert!(
+                error.contains("must not enable speculation"),
+                "{args}: {error}"
+            );
+            config.tasks = None;
+            let mut fast = config.profiles["default"].clone();
+            fast.grammar_profile = Some("safe".to_string());
+            config.profiles.insert("fast".to_string(), fast);
+            let error = ModelRegistry::model_entry_from_config(&config).unwrap_err();
+            assert!(
+                error.contains("explicitly disabling speculation"),
+                "{args}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_grammar_target_rejects_raw_speculation_without_typed_settings() {
+        let config: ModelConfig = serde_yaml::from_str(
+            r#"
+name: org/grammar-model
+tasks:
+  generate:
+    grammar_profile: safe
+profiles:
+  default:
+    adapter_path: sie_server.adapters.sglang.generation:SGLangGenerationAdapter
+  safe:
+    extends: default
+    adapter_options:
+      loadtime:
+        extra_launch_args: [--speculative-algorithm, NEXTN]
+"#,
+        )
+        .unwrap();
+        let error = ModelRegistry::model_entry_from_config(&config).unwrap_err();
+        assert!(error.contains("must not enable speculation"));
+    }
+
+    #[test]
+    fn test_grammar_route_variant_matching_benign_launch_args() {
+        let config: ModelConfig = serde_yaml::from_str(
+            r#"
+name: org/grammar-model
+tasks:
+  generate:
+    grammar_profile: safe
+profiles:
+  default:
+    adapter_path: sie_server.adapters.sglang.generation:SGLangGenerationAdapter
+    adapter_options:
+      loadtime:
+        grammar_backend: outlines
+        speculative: {enabled: false}
+        extra_launch_args: [--log-level, warning, --quantization, fp8]
+  safe:
+    extends: default
+  fast:
+    extends: default
+    adapter_options:
+      loadtime:
+        speculative: {enabled: true}
+"#,
+        )
+        .unwrap();
+        let (_dir, bundles_dir, models_dir) = create_test_dirs();
+        fs::write(
+            bundles_dir.join("default.yaml"),
+            "name: default\npriority: 10\nadapters:\n  - sie_server.adapters.sglang.generation\n",
+        )
+        .unwrap();
+        let registry = ModelRegistry::new(&bundles_dir, &models_dir, true);
+        registry.add_model_config(config).unwrap();
+        assert_eq!(
+            registry.grammar_route_variant("org/grammar-model"),
+            GrammarRoute::Keep
+        );
+        assert_eq!(
+            registry.grammar_route_variant("org/grammar-model:safe"),
+            GrammarRoute::Keep
+        );
+        assert_eq!(
+            registry.grammar_route_variant("org/grammar-model:fast"),
+            GrammarRoute::Rewrite("org/grammar-model:safe".to_string())
+        );
     }
 
     #[test]

--- a/packages/sie_server/src/sie_server/adapters/sglang/generation.py
+++ b/packages/sie_server/src/sie_server/adapters/sglang/generation.py
@@ -1138,6 +1138,8 @@ class SGLangGenerationAdapter(GenerationAdapter):
         # alongside ``return_logprob``. Added to the request bodies below.
         # Merge default sampling from model config (request fields win).
         for k, v in self._default_sampling.items():
+            if grammar is not None and k == "min_new_tokens":
+                continue
             sampling_params.setdefault(k, v)
         # A profile-level minimum is a soft default, while the request's
         # ``max_new_tokens`` is a hard caller limit. Cap the default to that

--- a/packages/sie_server/tests/adapters/test_sglang_generation.py
+++ b/packages/sie_server/tests/adapters/test_sglang_generation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import os
 import subprocess
 import sys
@@ -1036,6 +1037,112 @@ def test_generate_explicit_min_new_tokens_overrides_profile_default_when_valid(
     sampling_params = client_instance.stream.call_args.kwargs["json"]["sampling_params"]
     assert sampling_params["max_new_tokens"] == 8
     assert sampling_params["min_new_tokens"] == 2
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(GrammarSpec(kind="json_schema", value={"type": "string"}), id="json_schema"),
+        pytest.param(GrammarSpec(kind="regex", value="[a-z]+"), id="regex"),
+        pytest.param(GrammarSpec(kind="ebnf", value='root ::= "ok"'), id="ebnf"),
+    ]
+)
+def grammar_default_sampling_spec(request: pytest.FixtureRequest) -> GrammarSpec:
+    return request.param
+
+
+@pytest.mark.parametrize(
+    ("min_new_tokens", "top_k", "repetition_penalty"),
+    [
+        pytest.param(None, None, None, id="inherited"),
+        pytest.param(0, None, None, id="explicit-zero"),
+        pytest.param(2, 5, 1.2, id="explicit-overrides"),
+    ],
+)
+@patch("sie_server.adapters.sglang.generation.httpx.AsyncClient")
+def test_generate_grammar_default_sampling(
+    mock_async_client: MagicMock,
+    grammar_default_sampling_spec: GrammarSpec,
+    min_new_tokens: int | None,
+    top_k: int | None,
+    repetition_penalty: float | None,
+) -> None:
+    sse_lines = [
+        'data: {"text": "ok", "meta_info": {"prompt_tokens": 1, "completion_tokens": 1, "finish_reason": {"type": "stop"}}}',
+    ]
+    client_instance = _make_client_with_stream(_FakeStreamingResponse(sse_lines))
+    mock_async_client.return_value = client_instance
+    default_sampling = {"min_new_tokens": 10, "top_k": 17, "repetition_penalty": 1.1}
+    expected_defaults = default_sampling.copy()
+    adapter = SGLangGenerationAdapter("test-model", default_sampling=default_sampling)
+    adapter._server_url = "http://localhost:30005"
+    grammar = grammar_default_sampling_spec
+
+    asyncio.run(
+        collect_generation(
+            adapter.generate(
+                prompt="Hi",
+                max_new_tokens=3,
+                min_new_tokens=min_new_tokens,
+                top_k=top_k,
+                repetition_penalty=repetition_penalty,
+                grammar=grammar,
+            )
+        )
+    )
+
+    sampling_params = client_instance.stream.call_args.kwargs["json"]["sampling_params"]
+    assert sampling_params["max_new_tokens"] == 3
+    if min_new_tokens is None:
+        assert "min_new_tokens" not in sampling_params
+    else:
+        assert sampling_params["min_new_tokens"] == min_new_tokens
+    assert sampling_params["top_k"] == (17 if top_k is None else top_k)
+    assert sampling_params["repetition_penalty"] == pytest.approx(
+        1.1 if repetition_penalty is None else repetition_penalty
+    )
+    expected_grammar = json.dumps(grammar.value) if grammar.kind == "json_schema" else grammar.value
+    assert {key: sampling_params[key] for key in ("json_schema", "regex", "ebnf") if key in sampling_params} == {
+        grammar.kind: expected_grammar
+    }
+    assert adapter._default_sampling == expected_defaults
+    assert default_sampling == expected_defaults
+
+    for max_new_tokens in (1, 64):
+        asyncio.run(collect_generation(adapter.generate(prompt="Hi", max_new_tokens=max_new_tokens)))
+        unconstrained_sampling = client_instance.stream.call_args.kwargs["json"]["sampling_params"]
+        assert unconstrained_sampling["min_new_tokens"] == min(10, max_new_tokens)
+        assert unconstrained_sampling["top_k"] == 17
+        assert unconstrained_sampling["repetition_penalty"] == pytest.approx(1.1)
+        assert not {"json_schema", "regex", "ebnf"}.intersection(unconstrained_sampling)
+
+    assert adapter._default_sampling == expected_defaults
+    assert default_sampling == expected_defaults
+
+
+@patch("sie_server.adapters.sglang.generation.httpx.AsyncClient")
+def test_generate_grammar_default_sampling_rejects_explicit_min_above_max(
+    mock_async_client: MagicMock,
+    grammar_default_sampling_spec: GrammarSpec,
+) -> None:
+    adapter = SGLangGenerationAdapter(
+        "test-model",
+        default_sampling={"min_new_tokens": 10, "top_k": 17, "repetition_penalty": 1.1},
+    )
+    adapter._server_url = "http://localhost:30005"
+
+    with pytest.raises(ValueError, match=r"min_new_tokens \(10\) must not exceed max_new_tokens \(1\)"):
+        asyncio.run(
+            collect_generation(
+                adapter.generate(
+                    prompt="Hi",
+                    max_new_tokens=1,
+                    min_new_tokens=10,
+                    grammar=grammar_default_sampling_spec,
+                )
+            )
+        )
+
+    mock_async_client.assert_not_called()
 
 
 @pytest.mark.parametrize("seed", [-1, 0, 1])

--- a/tools/ci/tests/test_required_ci.py
+++ b/tools/ci/tests/test_required_ci.py
@@ -78,7 +78,7 @@ def test_bootstrap_is_uncached_and_checks_all_locks():
     workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
     bootstrap = workflow["jobs"]["bootstrap"]
     setup = next(step for step in bootstrap["steps"] if step.get("uses", "").startswith("jdx/mise-action@"))
-    assert setup["with"] == {"cache": False, "install": False}
+    assert setup["with"] == {"version": "2026.5.5", "cache": False, "install": False}
     script = (ROOT / "tools/ci/fresh_bootstrap.bash").read_text()
     assert "./tools/init.sh" in script
     assert "test ! -e .venv" in script
@@ -86,6 +86,18 @@ def test_bootstrap_is_uncached_and_checks_all_locks():
     for lock in ("uv.lock", "pnpm-lock.yaml", "Cargo.lock"):
         assert lock in script
     assert "sha256sum --check" in script
+
+
+def test_mise_workflow_setups_pin_concrete_versions():
+    for path in sorted((ROOT / ".github/workflows").glob("*.y*ml")):
+        workflow = yaml.safe_load(path.read_text())
+        for name, job in workflow["jobs"].items():
+            for step in job.get("steps", []):
+                if step.get("uses", "").startswith("jdx/mise-action@"):
+                    version = step.get("with", {}).get("version")
+                    assert re.fullmatch(r"[0-9]{4}\.[0-9]+\.[0-9]+", str(version)), (
+                        f"{path.name}: {name} must pin a concrete mise version"
+                    )
 
 
 @pytest.mark.parametrize(("mutate_lock", "old_venv", "code"), [(False, False, 0), (True, False, 1), (False, True, 1)])


### PR DESCRIPTION
## Changes

- Keep the base model selected for structured output when its default profile explicitly disables speculation and is compatible with the configured grammar fallback. Preserve fallback routing for incompatible defaults and explicit speculative profiles.
- Reject raw speculative launch options and opaque configuration-file overrides when validating grammar-safe profiles.
- Avoid inheriting a profile's minimum-token default for grammar-constrained SGLang requests. Explicit request minima and other sampling defaults remain unchanged.
- Add routing and mocked request-payload regression tests for compatible profiles, fallback cases, grammar types, and caller overrides.
- Pin previously unpinned mise setup steps to `2026.5.5` so CI and release jobs do not depend on an unpublished latest-version archive. Preserve the audio build's existing version pin.

## Validation

- Reproduced both failures before applying the fixes.
- 104 SGLang adapter tests passed without model downloads.
- Gateway grammar-routing and profile-scoped fallback tests passed offline; all 59 model-registry tests passed in both library and binary targets after the launch-argument guard was added.
- Rust formatting, Ruff checks, and `git diff --check` passed.
- 219 focused CI, public-tree, and release tests passed after pinning mise; workflow lint and source/release policy checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grammar-constrained generation by preventing incompatible speculative profiles from being selected.
  * Grammar requests no longer inherit default minimum token limits unintentionally.
  * Preserved sampling parameters and correctly handled JSON Schema, regex, and EBNF grammar formats.

* **Reliability**
  * Standardized CI and release workflows on a pinned toolchain version for more consistent builds and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->