### PR TITLE
feat(types): carry optional entity indices on Relation for span attribution

### DIFF
--- a/packages/sie_server/src/sie_server/types/responses.py
+++ b/packages/sie_server/src/sie_server/types/responses.py
@@ -124,12 +124,19 @@ class Relation(TypedDict):
         tail: Tail entity text.
         relation: Relation type label.
         score: Confidence score.
+        head_idx: Index of the head entity in the same item's entities list, when the
+            adapter can supply it. Lets a consumer recover the head's character offsets
+            without duplicating them here, which is the only way to attribute a relation
+            when the same surface text occurs more than once in the input.
+        tail_idx: Index of the tail entity in the same item's entities list.
     """
 
     head: str
     tail: str
     relation: str
     score: float
+    head_idx: NotRequired[int]
+    tail_idx: NotRequired[int]
 
 
 class Classification(TypedDict):


### PR DESCRIPTION
## Problem

`Relation`'s `head` and `tail` are plain strings, so a consumer cannot tell **which mention** a relation came from when the same surface text occurs more than once in the input.

That is not cosmetic — it breaks span-based anchoring. In a measured fixture, `"Dr Chen"` occurs at offsets 0 and 24; a relation naming `"Dr Chen"` is unattributable, and a consumer that anchors relations to caller-supplied entity spans has to either guess or drop it.

The asymmetry is already visible in the types:

```python
class Entity(TypedDict, total=False):
    text: str
    label: str
    score: float
    start: int | None      # <- offsets present
    end: int | None
    bbox: list[int] | None

class Relation(TypedDict):
    head: str              # <- bare text, no way back to a span
    tail: str
    relation: str
    score: float
```

## Why indices rather than nested objects or duplicated offsets

`ExtractOutput` already carries the per-item `entities` list, and `Entity` already carries `start`/`end`. So the linkage exists on both sides and only the **join** is missing. Two optional integers restore it by reference:

- **No duplication** of span data, so the two copies cannot drift apart.
- **No change to the type of an existing field**, so every current consumer keeps working — including `GLiRELAdapter`, which continues to emit four keys and stays valid.
- **Nothing is required to populate them.** Adapters that cannot supply indices simply omit them.

Nesting full objects under `head`/`tail` would be the alternative and is strictly worse: it changes the type of an existing field and breaks current consumers.

`NotRequired` rather than flipping the class to `total=False` — the four existing fields *are* required and should stay that way. `NotRequired` is already imported in this module.

## Prior art in the ecosystem

`knowledgator/gliner-relex-base-v1.0` already returns `entity_idx` on both the head and tail of every relation, so for that model family the information exists at the adapter boundary and is currently discarded on the way out.

## Compatibility

- No existing adapter is modified.
- No HTTP response changes for any current model.
- Purely additive, optional fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Relation responses now optionally include head and tail entity indexes.
  - Consumers can use these indexes to identify the correct entities when surface text is repeated and recover their character offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->