### PR TITLE
fix(server): preserve TensorRT completion text

### DIFF
--- a/packages/sie_server/README.md
+++ b/packages/sie_server/README.md
@@ -39,6 +39,15 @@ pip install sie-server
 sie-server serve --port 8080 --device cuda:0
 ```
 
+### TensorRT-LLM generation
+
+TensorRT-LLM buffers completion token IDs and emits the final text together only
+after generation finishes and the terminal stream is verified, even with
+`stream=True`. This preserves context-sensitive spacing and punctuation and
+removes matched stop sequences consistently from returned text, completion-token
+usage, and logprobs. Long completions delay the first visible text; existing
+request timeouts still apply. Other adapters are unaffected.
+
 ## Configuration
 
 `sie-server` reads its config from `SIE_*` environment variables (Pydantic

--- a/packages/sie_server/src/sie_server/adapters/tensorrt_llm/generation.py
+++ b/packages/sie_server/src/sie_server/adapters/tensorrt_llm/generation.py
@@ -47,6 +47,38 @@ _POOL_TIMEOUT_S = 10.0
 _CLIENT_CLOSE_TIMEOUT_S = 2.0
 
 
+def _decode_completion(tokenizer: Any, token_ids: list[int]) -> str:
+    try:
+        text = tokenizer.decode(token_ids, skip_special_tokens=True)
+    except Exception as exc:
+        raise RuntimeError("TensorRT-LLM completion detokenization failed") from exc
+    if not isinstance(text, str):
+        raise RuntimeError("TensorRT-LLM completion detokenization returned a non-string")
+    return text
+
+
+def _trim_textual_stop(tokenizer: Any, token_ids: list[int], stop_reason: str) -> tuple[str, int]:
+    """Trim the exact stop-token suffix retained by TensorRT-LLM rc24."""
+    if not stop_reason:
+        raise RuntimeError("TensorRT-LLM textual stop reason must be non-empty")
+    try:
+        stop_token_ids = tokenizer.encode(stop_reason, add_special_tokens=False)
+    except Exception as exc:
+        raise RuntimeError("TensorRT-LLM textual stop tokenization failed") from exc
+    if (
+        not isinstance(stop_token_ids, list)
+        or not stop_token_ids
+        or any(
+            isinstance(token_id, bool) or not isinstance(token_id, int) or token_id < 0 for token_id in stop_token_ids
+        )
+    ):
+        raise RuntimeError("TensorRT-LLM textual stop tokenization returned invalid token ids")
+    trim_token_count = len(stop_token_ids)
+    if token_ids[-trim_token_count:] != stop_token_ids:
+        raise RuntimeError("TensorRT-LLM textual stop reason does not match the token-id suffix")
+    return _decode_completion(tokenizer, token_ids[:-trim_token_count]), trim_token_count
+
+
 def _positive_int(name: str, value: int) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise ValueError(f"{name} must be an integer > 0")
@@ -633,6 +665,7 @@ class TensorRTLLMGenerationAdapter(GenerationAdapter):
             "max_tokens": max_new_tokens,
             "temperature": temperature,
             "top_p": top_p,
+            "detokenize": False,
             "stream": True,
             "stream_options": {"include_usage": True},
             "n": 1,
@@ -648,6 +681,8 @@ class TensorRTLLMGenerationAdapter(GenerationAdapter):
             "logit_bias": logit_bias,
         }
         request.update({name: value for name, value in optional.items() if value is not None})
+        if stop:
+            request["include_stop_str_in_output"] = True
         if logprobs:
             request["logprobs"] = top_logprobs if top_logprobs is not None else 1
 
@@ -686,8 +721,14 @@ class TensorRTLLMGenerationAdapter(GenerationAdapter):
         client = await self._get_or_create_http_client()
         finish_reason: FinishReason | None = None
         usage_completion_tokens: int | None = None
-        first_text_emitted = False
+        terminal_stop_reason: str | int | None = None
         saw_done = False
+        received_token_ids: list[int] = []
+        received_logprobs: list[dict[str, Any]] = []
+        stop_strings = cast("list[str]", request.get("stop") or [])
+        tokenizer = self._tokenizer
+        if tokenizer is None:
+            raise RuntimeError(ERR_NOT_LOADED)
 
         async with client.stream("POST", f"{server_url}/v1/completions", json=request) as response:
             if response.status_code != 200:
@@ -703,13 +744,40 @@ class TensorRTLLMGenerationAdapter(GenerationAdapter):
                 if data == "[DONE]":
                     if finish_reason is None or usage_completion_tokens is None:
                         raise RuntimeError("TensorRT-LLM completion ended without finish reason and usage")
+                    if usage_completion_tokens != len(received_token_ids):
+                        raise RuntimeError("TensorRT-LLM completion usage does not match streamed token ids")
+                    trim_token_count = 0
+                    final_text: str | None = None
+                    if isinstance(terminal_stop_reason, str):
+                        final_text, trim_token_count = _trim_textual_stop(
+                            tokenizer, received_token_ids, terminal_stop_reason
+                        )
+                    elif terminal_stop_reason is not None and request.get("include_stop_str_in_output") is True:
+                        if not received_token_ids or received_token_ids[-1] != terminal_stop_reason:
+                            raise RuntimeError("TensorRT-LLM token stop reason does not match the token-id suffix")
+                        trim_token_count = 1
+                    completion_token_ids = (
+                        received_token_ids[:-trim_token_count] if trim_token_count else received_token_ids
+                    )
+                    completion_logprobs = (
+                        received_logprobs[:-trim_token_count] if trim_token_count else received_logprobs
+                    )
+                    if final_text is None:
+                        final_text = _decode_completion(tokenizer, completion_token_ids)
+                    final_logprobs = tuple(completion_logprobs) or None
+                    if final_text or final_logprobs:
+                        yield GenerationChunk(
+                            text_delta=final_text,
+                            is_first=bool(final_text),
+                            logprobs=final_logprobs,
+                        )
                     saw_done = True
                     yield GenerationChunk(
                         text_delta="",
                         done=True,
                         finish_reason=finish_reason,
                         prompt_tokens=prompt_token_count,
-                        completion_tokens=usage_completion_tokens,
+                        completion_tokens=len(completion_token_ids),
                     )
                     break
                 try:
@@ -727,38 +795,74 @@ class TensorRTLLMGenerationAdapter(GenerationAdapter):
                 if not isinstance(choices, list):
                     raise RuntimeError("TensorRT-LLM completion event is missing choices")
                 if choices:
-                    if len(choices) != 1 or not isinstance(choices[0], Mapping) or choices[0].get("index", 0) != 0:
+                    if finish_reason is not None:
+                        raise RuntimeError("TensorRT-LLM completion emitted a choice after its terminal choice")
+                    if len(choices) != 1 or not isinstance(choices[0], Mapping):
                         raise RuntimeError("TensorRT-LLM completion emitted unsupported multiple choices")
                     choice = choices[0]
-                    text = choice.get("text", "")
-                    if not isinstance(text, str):
-                        raise RuntimeError("TensorRT-LLM completion text must be a string")
-                    event_finish = choice.get("finish_reason")
+                    index = choice.get("index")
+                    if type(index) is not int or index != 0:
+                        raise RuntimeError("TensorRT-LLM completion emitted unsupported multiple choices")
+                    if "text" not in choice or not isinstance(choice["text"], str):
+                        raise RuntimeError("TensorRT-LLM completion text must be an explicit string")
+                    if choice["text"]:
+                        raise RuntimeError("TensorRT-LLM completion text must be empty when detokenization is disabled")
+                    if "token_ids" not in choice:
+                        raise RuntimeError("TensorRT-LLM completion token ids must be explicit arrays")
+                    token_ids = choice["token_ids"]
+                    if not isinstance(token_ids, list) or any(
+                        isinstance(token_id, bool) or not isinstance(token_id, int) or token_id < 0
+                        for token_id in token_ids
+                    ):
+                        raise RuntimeError("TensorRT-LLM completion token ids must be non-negative integer arrays")
+                    if "finish_reason" not in choice:
+                        raise RuntimeError("TensorRT-LLM completion finish reason must be explicit")
+                    event_finish = choice["finish_reason"]
+                    if event_finish is not None and (
+                        not isinstance(event_finish, str) or event_finish not in {"stop", "length"}
+                    ):
+                        raise RuntimeError("TensorRT-LLM completion finish reason is invalid")
+                    if "stop_reason" not in choice:
+                        raise RuntimeError("TensorRT-LLM completion stop reason must be explicit")
+                    event_stop_reason = choice["stop_reason"]
+                    if (
+                        isinstance(event_stop_reason, bool)
+                        or (isinstance(event_stop_reason, int) and event_stop_reason < 0)
+                        or not isinstance(event_stop_reason, str | int | None)
+                    ):
+                        raise RuntimeError("TensorRT-LLM completion stop reason is invalid")
+                    if event_finish in {None, "length"} and event_stop_reason is not None:
+                        raise RuntimeError("TensorRT-LLM completion emitted a stop reason without a stop finish")
+                    if isinstance(event_stop_reason, str) and event_stop_reason not in stop_strings:
+                        raise RuntimeError("TensorRT-LLM completion emitted an unrequested textual stop reason")
                     if event_finish is not None:
                         if event_finish not in {"stop", "length"}:
                             raise RuntimeError(f"unsupported TensorRT-LLM finish reason {event_finish!r}")
                         if finish_reason is not None:
                             raise RuntimeError("TensorRT-LLM completion emitted multiple finish reasons")
                         finish_reason = cast("FinishReason", event_finish)
-                    if text:
-                        if finish_reason is not None and event_finish is None:
-                            raise RuntimeError("TensorRT-LLM emitted text after its terminal choice")
-                        choice_logprobs = _completion_logprobs(choice.get("logprobs"))
-                        if logprobs_requested and choice_logprobs is None:
+                        terminal_stop_reason = event_stop_reason
+                    choice_logprobs = _completion_logprobs(choice.get("logprobs"))
+                    if choice.get("logprobs") is not None and len(choice_logprobs or ()) != len(token_ids):
+                        raise RuntimeError("TensorRT-LLM completion logprobs do not align with token ids")
+                    if logprobs_requested:
+                        if token_ids and choice_logprobs is None:
                             raise RuntimeError("TensorRT-LLM omitted requested completion logprobs")
-                        yield GenerationChunk(
-                            text_delta=text,
-                            is_first=not first_text_emitted,
-                            logprobs=choice_logprobs,
-                        )
-                        first_text_emitted = True
+                    elif choice.get("logprobs") is not None:
+                        raise RuntimeError("TensorRT-LLM emitted unrequested completion logprobs")
+                    received_token_ids.extend(token_ids)
+                    if choice_logprobs:
+                        received_logprobs.extend(choice_logprobs)
 
                 event_usage = event.get("usage")
                 if event_usage is not None:
+                    if choices or finish_reason is None:
+                        raise RuntimeError("TensorRT-LLM completion emitted usage before its terminal choice")
                     if usage_completion_tokens is not None or not isinstance(event_usage, Mapping):
                         raise RuntimeError("TensorRT-LLM completion emitted invalid duplicate usage")
                     child_prompt_tokens = event_usage.get("prompt_tokens")
                     child_completion_tokens = event_usage.get("completion_tokens")
+                    child_total_tokens = event_usage.get("total_tokens")
                     if (
                         isinstance(child_prompt_tokens, bool)
                         or not isinstance(child_prompt_tokens, int)
@@ -766,6 +870,9 @@ class TensorRTLLMGenerationAdapter(GenerationAdapter):
                         or isinstance(child_completion_tokens, bool)
                         or not isinstance(child_completion_tokens, int)
                         or child_completion_tokens < 0
+                        or isinstance(child_total_tokens, bool)
+                        or not isinstance(child_total_tokens, int)
+                        or child_total_tokens != child_prompt_tokens + child_completion_tokens
                     ):
                         raise RuntimeError("TensorRT-LLM completion usage is invalid")
                     # rc24 reports its internal decoder prefix here for

--- a/packages/sie_server/tests/adapters/test_tensorrt_llm_generation.py
+++ b/packages/sie_server/tests/adapters/test_tensorrt_llm_generation.py
@@ -33,6 +33,29 @@ class _FixtureTokenizer:
         self.calls.append((prompt, add_special_tokens))
         return list(range(len(prompt.split()) + int(add_special_tokens)))
 
+    def decode(self, token_ids: list[int], *, skip_special_tokens: bool) -> str:
+        assert skip_special_tokens
+        pieces = {10: " bonjour", 11: " monde", 12: "ok", 13: "x", 14: "late"}
+        return "".join(pieces[token_id] for token_id in token_ids)
+
+
+class _SequenceTokenizer(_FixtureTokenizer):
+    def __init__(self, sequences: dict[tuple[int, ...], str]) -> None:
+        super().__init__()
+        self.sequences = sequences
+        self.decode_calls: list[tuple[tuple[int, ...], bool]] = []
+
+    def encode(self, prompt: str, *, add_special_tokens: bool) -> list[int]:
+        if not add_special_tokens:
+            self.calls.append((prompt, add_special_tokens))
+            assert prompt == "<stop>"
+            return [90, 91]
+        return super().encode(prompt, add_special_tokens=add_special_tokens)
+
+    def decode(self, token_ids: list[int], *, skip_special_tokens: bool) -> str:
+        self.decode_calls.append((tuple(token_ids), skip_special_tokens))
+        return self.sequences[tuple(token_ids)]
+
 
 def _adapter(**kwargs: Any) -> TensorRTLLMGenerationAdapter:
     adapter = TensorRTLLMGenerationAdapter(
@@ -63,6 +86,383 @@ def _sse(*events: object) -> bytes:
     lines = [f"data: {json.dumps(event)}\n\n" for event in events]
     lines.append("data: [DONE]\n\n")
     return "".join(lines).encode()
+
+
+def _choice(token_ids: list[int], **fields: Any) -> dict[str, Any]:
+    return {
+        "choices": [
+            {"index": 0, "text": "", "token_ids": token_ids, "finish_reason": None, "stop_reason": None, **fields}
+        ]
+    }
+
+
+def _usage(completion_tokens: int, *, prompt_tokens: int = 1) -> dict[str, Any]:
+    return {
+        "choices": [],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+def _token_logprobs(*tokens: str) -> dict[str, Any]:
+    return {"tokens": list(tokens), "token_logprobs": [-0.2] * len(tokens), "top_logprobs": [None] * len(tokens)}
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "sequences", "expected"),
+    [
+        ([10, 11, 12], {(10,): "Hello", (11,): ",", (12,): "world", (10, 11, 12): "Hello, world"}, "Hello, world"),
+        ([70, 71, 70, 71], {(70,): "", (71,): ".", (70, 71, 70, 71): ". ."}, ". ."),
+        (
+            list(range(10, 50)),
+            {(10,): "old prefix", tuple(range(10, 49)): "old prefix continued", tuple(range(10, 50)): "rewritten!"},
+            "rewritten!",
+        ),
+    ],
+)
+def test_preserves_token_stream_whole_sequence_text(
+    token_ids: list[int], sequences: dict[tuple[int, ...], str], expected: str
+) -> None:
+    adapter = _adapter()
+    tokenizer = _SequenceTokenizer(sequences)
+    adapter._tokenizer = tokenizer
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(
+            200,
+            content=_sse(
+                *(_choice([token_id]) for token_id in token_ids),
+                _choice([], finish_reason="length"),
+                _usage(len(token_ids)),
+            ),
+        )
+
+    adapter._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        chunks = asyncio.run(_collect(adapter.generate("exact  prompt", max_new_tokens=64, stream=True)))
+        assert [chunk.text_delta for chunk in chunks] == [expected, ""]
+        assert chunks[0].is_first is True
+        assert chunks[-1].done is True
+        assert chunks[-1].finish_reason == "length"
+        assert (chunks[-1].prompt_tokens, chunks[-1].completion_tokens) == (3, len(token_ids))
+        assert tokenizer.decode_calls == [(tuple(token_ids), True)]
+        assert captured["prompt"] == "exact  prompt"
+        assert captured["detokenize"] is False
+        assert "include_stop_str_in_output" not in captured
+    finally:
+        asyncio.run(adapter.aclose_client())
+
+
+def test_preserves_token_stream_split_stop_and_logprob_alignment() -> None:
+    adapter = _adapter()
+    tokenizer = _SequenceTokenizer({(10, 90, 91, 11): "earlier <stop> stays"})
+    adapter._tokenizer = tokenizer
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(
+            200,
+            content=_sse(
+                _choice([10, 90, 91], logprobs=_token_logprobs("earlier", "<", "stop>")),
+                _choice([11, 90], logprobs=_token_logprobs(" stays", "<")),
+                _choice([91], finish_reason="stop", stop_reason="<stop>", logprobs=_token_logprobs("stop>")),
+                _usage(6),
+            ),
+        )
+
+    adapter._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        chunks = asyncio.run(_collect(adapter.generate("prompt", max_new_tokens=8, stop=["<stop>"], logprobs=True)))
+        assert [chunk.text_delta for chunk in chunks] == ["earlier <stop> stays", ""]
+        assert [entry["token"] for entry in chunks[0].logprobs] == ["earlier", "<", "stop>", " stays"]
+        assert (chunks[-1].prompt_tokens, chunks[-1].completion_tokens) == (2, 4)
+        assert tokenizer.decode_calls == [((10, 90, 91, 11), True)]
+        assert tokenizer.calls == [("prompt", True), ("<stop>", False)]
+        assert captured["include_stop_str_in_output"] is True
+    finally:
+        asyncio.run(adapter.aclose_client())
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        (_choice([10], finish_reason="stop"), _usage(2)),
+        (_choice([10], finish_reason="stop"), {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}),
+        (
+            _choice([10], finish_reason="stop"),
+            {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 9}},
+        ),
+        (_usage(1), _choice([10], finish_reason="stop")),
+        (_choice([10], finish_reason="stop"), _choice([]), _usage(1)),
+        ({"choices": [{"text": "", "token_ids": [10], "finish_reason": "stop", "stop_reason": None}]}, _usage(1)),
+        ({"choices": [{"index": 0, "token_ids": [10], "finish_reason": "stop", "stop_reason": None}]}, _usage(1)),
+        ({"choices": [{"index": 0, "text": "", "finish_reason": "stop", "stop_reason": None}]}, _usage(1)),
+        ({"choices": [{"index": 0, "text": "", "token_ids": [10], "finish_reason": "stop"}]}, _usage(1)),
+    ],
+)
+def test_preserves_token_stream_rejects_incomplete_terminal_evidence(events: tuple[object, ...]) -> None:
+    adapter = _adapter()
+    tokenizer = _SequenceTokenizer({(10,): "buffered"})
+    adapter._tokenizer = tokenizer
+    adapter._http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, content=_sse(*events)))
+    )
+    emitted: list[Any] = []
+
+    async def consume() -> None:
+        async for chunk in adapter.generate("prompt", max_new_tokens=4):
+            emitted.append(chunk)
+
+    try:
+        with pytest.raises(RuntimeError):
+            asyncio.run(consume())
+        assert emitted == []
+        assert tokenizer.decode_calls == []
+        assert adapter._active_generations == 0
+    finally:
+        asyncio.run(adapter.aclose_client())
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "finish_reason", "stop_reason", "stops", "retained_ids", "text"),
+    [
+        ([10, 90, 91], "length", None, ["<stop>"], [10, 90, 91], "hello<stop>"),
+        ([], "stop", None, None, [], ""),
+        ([90, 91], "stop", "<stop>", ["<stop>"], [], ""),
+        ([10, 99], "stop", 99, ["<stop>"], [10], "hello"),
+        ([10], "stop", 99, None, [10], "hello"),
+        ([10], "stop", None, [], [10], "hello"),
+        ([99], "stop", None, None, [99], ""),
+    ],
+)
+def test_stop_suffix_and_empty_completion_accounting(
+    token_ids: list[int],
+    finish_reason: str,
+    stop_reason: str | int | None,
+    stops: list[str] | None,
+    retained_ids: list[int],
+    text: str,
+) -> None:
+    adapter = _adapter()
+    tokenizer = _SequenceTokenizer({tuple(retained_ids): text})
+    adapter._tokenizer = tokenizer
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(
+            200,
+            content=_sse(
+                _choice(
+                    token_ids,
+                    finish_reason=finish_reason,
+                    stop_reason=stop_reason,
+                    logprobs=_token_logprobs(*(str(token_id) for token_id in token_ids)),
+                ),
+                _usage(len(token_ids)),
+            ),
+        )
+
+    adapter._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        chunks = asyncio.run(_collect(adapter.generate("prompt", max_new_tokens=8, stop=stops, logprobs=True)))
+        assert len(chunks) == (2 if retained_ids else 1)
+        if retained_ids:
+            assert chunks[0].text_delta == text
+            assert chunks[0].is_first is bool(text)
+            assert [entry["token"] for entry in chunks[0].logprobs] == [str(token_id) for token_id in retained_ids]
+        assert chunks[-1].done is True
+        assert chunks[-1].is_first is False
+        assert chunks[-1].finish_reason == finish_reason
+        assert (chunks[-1].prompt_tokens, chunks[-1].completion_tokens) == (2, len(retained_ids))
+        assert tokenizer.decode_calls == [(tuple(retained_ids), True)]
+        assert ("include_stop_str_in_output" in captured) is bool(stops)
+    finally:
+        asyncio.run(adapter.aclose_client())
+
+
+def _assert_buffered_failure(
+    content: bytes, *, tokenizer: Any = None, message: str = "TensorRT-LLM", **parameters: Any
+) -> None:
+    adapter = _adapter()
+    adapter._tokenizer = tokenizer or _SequenceTokenizer({(10,): "buffered"})
+    adapter._http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, content=content))
+    )
+    emitted: list[Any] = []
+
+    async def consume() -> None:
+        async for chunk in adapter.generate("prompt", max_new_tokens=8, **parameters):
+            emitted.append(chunk)
+
+    try:
+        with pytest.raises(RuntimeError, match=message):
+            asyncio.run(consume())
+        assert emitted == []
+        assert adapter._active_generations == 0
+    finally:
+        asyncio.run(adapter.aclose_client())
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("index", True, "multiple choices"),
+        ("index", 0.0, "multiple choices"),
+        ("index", "0", "multiple choices"),
+        ("text", None, "explicit string"),
+        ("text", "child text", "must be empty"),
+        ("token_ids", None, "integer arrays"),
+        ("token_ids", [True], "integer arrays"),
+        ("token_ids", [-1], "integer arrays"),
+        ("token_ids", [1.5], "integer arrays"),
+        ("token_ids", ["10"], "integer arrays"),
+        ("token_ids", [[10]], "integer arrays"),
+        ("finish_reason", [], "finish reason is invalid"),
+        ("finish_reason", True, "finish reason is invalid"),
+        ("finish_reason", "unsupported", "finish reason is invalid"),
+        ("stop_reason", True, "stop reason is invalid"),
+        ("stop_reason", -1, "stop reason is invalid"),
+        ("stop_reason", 1.5, "stop reason is invalid"),
+        ("stop_reason", {}, "stop reason is invalid"),
+        ("stop_reason", "", "unrequested textual stop"),
+        ("stop_reason", "unrequested", "unrequested textual stop"),
+    ],
+)
+def test_stream_rejects_invalid_token_choice_fields(field: str, value: Any, message: str) -> None:
+    event = _choice([10], finish_reason="stop")
+    event["choices"][0][field] = value
+    _assert_buffered_failure(_sse(event, _usage(1)), message=message)
+
+
+@pytest.mark.parametrize("field", ["index", "text", "token_ids", "finish_reason", "stop_reason"])
+def test_stream_rejects_missing_token_choice_fields(field: str) -> None:
+    event = _choice([10], finish_reason="stop")
+    del event["choices"][0][field]
+    _assert_buffered_failure(_sse(event, _usage(1)))
+
+
+@pytest.mark.parametrize("finish_reason", [None, "length"])
+@pytest.mark.parametrize("stop_reason", [99, "<stop>"])
+def test_stream_rejects_stop_reason_without_stop_finish(finish_reason: str | None, stop_reason: str | int) -> None:
+    _assert_buffered_failure(
+        _sse(_choice([10], finish_reason=finish_reason, stop_reason=stop_reason), _usage(1)),
+        stop=["<stop>"],
+        message="without a stop finish",
+    )
+
+
+def test_stream_rejects_empty_textual_stop_even_if_requested() -> None:
+    _assert_buffered_failure(
+        _sse(_choice([10], finish_reason="stop", stop_reason=""), _usage(1)),
+        stop=[""],
+        message="textual stop reason must be non-empty",
+    )
+
+
+@pytest.mark.parametrize("stop_reason", [99, "<stop>"])
+def test_stream_rejects_stop_suffix_mismatch_even_with_matching_decoded_text(stop_reason: str | int) -> None:
+    _assert_buffered_failure(
+        _sse(_choice([10], finish_reason="stop", stop_reason=stop_reason), _usage(1)),
+        tokenizer=_SequenceTokenizer({(10,): "<stop>"}),
+        stop=["<stop>"],
+        message="does not match the token-id suffix",
+    )
+
+
+@pytest.mark.parametrize("stop_ids", [None, (), [], [True], [-1], ["90"], [90.0], ValueError("bad tokenizer")])
+def test_stream_rejects_invalid_stop_tokenization(stop_ids: Any) -> None:
+    class BrokenStopTokenizer(_SequenceTokenizer):
+        def encode(self, prompt: str, *, add_special_tokens: bool) -> Any:
+            if add_special_tokens:
+                return super().encode(prompt, add_special_tokens=True)
+            if isinstance(stop_ids, Exception):
+                raise stop_ids
+            return stop_ids
+
+    _assert_buffered_failure(
+        _sse(_choice([10, 90, 91], finish_reason="stop", stop_reason="<stop>"), _usage(3)),
+        tokenizer=BrokenStopTokenizer({(10,): "hello"}),
+        stop=["<stop>"],
+        message="textual stop tokenization",
+    )
+
+
+@pytest.mark.parametrize("decoded", [None, 1, [], ValueError("bad tokenizer")])
+def test_stream_rejects_invalid_whole_completion_decode(decoded: Any) -> None:
+    class BrokenDecodeTokenizer(_FixtureTokenizer):
+        def decode(self, token_ids: list[int], *, skip_special_tokens: bool) -> Any:
+            if isinstance(decoded, Exception):
+                raise decoded
+            return decoded
+
+    _assert_buffered_failure(
+        _sse(_choice([10], finish_reason="stop"), _usage(1)),
+        tokenizer=BrokenDecodeTokenizer(),
+        message="completion detokenization",
+    )
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "logprobs", "requested", "message"),
+    [
+        ([10], None, True, "omitted requested"),
+        ([10], _token_logprobs(), True, "do not align"),
+        ([10], _token_logprobs(), False, "do not align"),
+        ([10], _token_logprobs("one", "two"), True, "do not align"),
+        ([10], _token_logprobs("one"), False, "unrequested completion logprobs"),
+        ([], _token_logprobs(), False, "unrequested completion logprobs"),
+        ([], _token_logprobs("one"), True, "do not align"),
+        ([10], {"tokens": ["one"], "token_logprobs": [-0.2], "top_logprobs": [[]]}, True, "token-to-logprob"),
+    ],
+)
+def test_stream_rejects_unaligned_or_unrequested_logprobs(
+    token_ids: list[int], logprobs: Any, requested: bool, message: str
+) -> None:
+    _assert_buffered_failure(
+        _sse(_choice(token_ids, finish_reason="stop", logprobs=logprobs), _usage(len(token_ids))),
+        logprobs=requested,
+        message=message,
+    )
+
+
+@pytest.mark.parametrize("field", ["prompt_tokens", "completion_tokens", "total_tokens"])
+@pytest.mark.parametrize("value", [None, True, -1, 1.5, "1"])
+def test_stream_rejects_invalid_usage_counts(field: str, value: Any) -> None:
+    usage = _usage(1)
+    usage["usage"][field] = value
+    _assert_buffered_failure(_sse(_choice([10], finish_reason="stop"), usage), message="usage is invalid")
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        ([],),
+        ({"choices": None},),
+        ({"choices": [0]},),
+        ({"choices": [{}, {}]},),
+        ({**_choice([10], finish_reason="stop"), "usage": _usage(1)["usage"]},),
+        (_choice([10], finish_reason="stop"),),
+        (_choice([10], finish_reason="stop"), _usage(1), _usage(1)),
+        (_choice([10], finish_reason="stop"), _choice([], finish_reason="stop"), _usage(1)),
+        (_choice([10]), {"error": {"message": "engine failed"}}),
+    ],
+)
+def test_stream_rejects_invalid_event_and_terminal_order_without_output(events: tuple[object, ...]) -> None:
+    _assert_buffered_failure(_sse(*events))
+
+
+def test_stream_requires_done_before_exposing_buffered_output() -> None:
+    _assert_buffered_failure(
+        _sse(_choice([10], finish_reason="stop"), _usage(1)).removesuffix(b"data: [DONE]\n\n"),
+        message=r"before \[DONE\]",
+    )
 
 
 def test_context_length_accounting_is_independent() -> None:
@@ -623,8 +1023,10 @@ def test_generation_maps_completion_controls_text_finish_usage_and_logprobs() ->
                     "choices": [
                         {
                             "index": 0,
-                            "text": " bonjour",
+                            "text": "",
+                            "token_ids": [10],
                             "finish_reason": None,
+                            "stop_reason": None,
                             "logprobs": {
                                 "tokens": [" bonjour"],
                                 "token_logprobs": [-0.2],
@@ -634,7 +1036,7 @@ def test_generation_maps_completion_controls_text_finish_usage_and_logprobs() ->
                         }
                     ]
                 },
-                {"choices": [{"index": 0, "text": "", "finish_reason": "stop"}]},
+                _choice([], finish_reason="stop"),
                 {
                     "choices": [],
                     "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
@@ -671,10 +1073,12 @@ def test_generation_maps_completion_controls_text_finish_usage_and_logprobs() ->
         "max_tokens": 9,
         "temperature": 0.2,
         "top_p": 0.9,
+        "detokenize": False,
         "stream": True,
         "stream_options": {"include_usage": True},
         "n": 1,
         "stop": ["!"],
+        "include_stop_str_in_output": True,
         "frequency_penalty": 0.1,
         "presence_penalty": 0.2,
         "top_k": 12,
@@ -768,8 +1172,10 @@ def test_stream_completion_normalizes_null_top_alternatives() -> None:
                         "choices": [
                             {
                                 "index": 0,
-                                "text": " bonjour monde",
+                                "text": "",
+                                "token_ids": [10, 11],
                                 "finish_reason": None,
+                                "stop_reason": None,
                                 "logprobs": {
                                     "tokens": [" bonjour", " monde"],
                                     "token_logprobs": [-0.2, -0.3],
@@ -778,10 +1184,10 @@ def test_stream_completion_normalizes_null_top_alternatives() -> None:
                             }
                         ]
                     },
-                    {"choices": [{"index": 0, "text": "", "finish_reason": "stop"}]},
+                    _choice([], finish_reason="stop"),
                     {
                         "choices": [],
-                        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
                     },
                 ),
             )
@@ -835,11 +1241,11 @@ def test_unload_closes_http_client_before_child_teardown(monkeypatch: pytest.Mon
     ("events", "message"),
     [
         (
-            ({"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},),
-            "ended without finish reason and usage",
+            (_usage(1),),
+            "usage before its terminal choice",
         ),
         (
-            ({"choices": [{"index": 0, "text": "x", "finish_reason": "stop"}]},),
+            (_choice([13], finish_reason="stop"),),
             "ended without finish reason and usage",
         ),
         (({"error": {"message": "engine rejected"}, "choices": []},), "completion error: engine rejected"),
@@ -864,8 +1270,7 @@ def test_stream_fails_when_eof_arrives_without_done() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            content=b'data: {"choices":[{"index":0,"text":"x","finish_reason":"stop"}]}\n\n'
-            b'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n',
+            content=_sse(_choice([13], finish_reason="stop"), _usage(1)).removesuffix(b"data: [DONE]\n\n"),
         )
 
     adapter._http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
@@ -911,8 +1316,8 @@ def test_generation_allows_encoder_limit_after_special_token_accounting() -> Non
             lambda _request: httpx.Response(
                 200,
                 content=_sse(
-                    {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
-                    {"choices": [], "usage": {"prompt_tokens": 128, "completion_tokens": 1}},
+                    _choice([12], finish_reason="stop"),
+                    _usage(1, prompt_tokens=128),
                 ),
             )
         )
@@ -947,8 +1352,10 @@ def test_generation_rejects_encoder_overflow_before_dispatch_after_special_token
                     "choices": [
                         {
                             "index": 0,
-                            "text": "x",
+                            "text": "",
+                            "token_ids": [13],
                             "finish_reason": None,
+                            "stop_reason": None,
                             "logprobs": {"tokens": ["x"], "token_logprobs": []},
                         }
                     ]
@@ -958,23 +1365,23 @@ def test_generation_rejects_encoder_overflow_before_dispatch_after_special_token
         ),
         (
             (
-                {"choices": [{"index": 0, "text": "", "finish_reason": "stop"}]},
-                {"choices": [{"index": 0, "text": "late", "finish_reason": None}]},
+                _choice([], finish_reason="stop"),
+                _choice([14]),
             ),
-            "text after its terminal choice",
+            "choice after its terminal choice",
         ),
         (
             (
-                {"choices": [{"index": 0, "text": "", "finish_reason": "stop"}]},
+                _choice([], finish_reason="stop"),
                 {"choices": [], "usage": {"prompt_tokens": True, "completion_tokens": 1}},
             ),
             "usage is invalid",
         ),
         (
             (
-                {"choices": [{"index": 0, "text": "", "finish_reason": "stop"}]},
-                {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
-                {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+                _choice([], finish_reason="stop"),
+                _usage(0),
+                _usage(0),
             ),
             "duplicate usage",
         ),
@@ -1056,8 +1463,8 @@ def test_preflight_prompt_count_is_reused_by_matching_dispatch() -> None:
                 lambda _request: httpx.Response(
                     200,
                     content=_sse(
-                        {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
-                        {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+                        _choice([12], finish_reason="stop"),
+                        _usage(1),
                     ),
                 )
             )
@@ -1081,8 +1488,8 @@ def test_preflight_result_is_consumed_once_even_for_an_identical_second_dispatch
                 lambda _request: httpx.Response(
                     200,
                     content=_sse(
-                        {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
-                        {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+                        _choice([12], finish_reason="stop"),
+                        _usage(1),
                     ),
                 )
             )
@@ -1111,8 +1518,8 @@ def test_abandoned_unstarted_preflight_dispatch_cannot_reuse_prompt_count() -> N
                 lambda _request: httpx.Response(
                     200,
                     content=_sse(
-                        {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
-                        {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+                        _choice([12], finish_reason="stop"),
+                        _usage(1),
                     ),
                 )
             )
@@ -1143,8 +1550,8 @@ def test_preflight_result_cannot_cross_adapter_ownership() -> None:
                 lambda _request: httpx.Response(
                     200,
                     content=_sse(
-                        {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
-                        {"choices": [], "usage": {"prompt_tokens": 2, "completion_tokens": 1}},
+                        _choice([12], finish_reason="stop"),
+                        _usage(1, prompt_tokens=2),
                     ),
                 )
             )
@@ -1184,8 +1591,8 @@ def test_preflight_results_are_request_scoped_across_concurrent_child_tasks() ->
                 lambda _request: httpx.Response(
                     200,
                     content=_sse(
-                        {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
-                        {"choices": [], "usage": {"prompt_tokens": 2, "completion_tokens": 1}},
+                        _choice([12], finish_reason="stop"),
+                        _usage(1, prompt_tokens=2),
                     ),
                 )
             )
@@ -1211,9 +1618,11 @@ class _CancellableStream(httpx.AsyncByteStream):
     def __init__(self) -> None:
         self.closed = False
         self.block = asyncio.Event()
+        self.consumed = asyncio.Event()
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
-        yield b'data: {"choices":[{"index":0,"text":"x","finish_reason":null}]}\n\n'
+        yield _sse(_choice([13])).removesuffix(b"data: [DONE]\n\n")
+        self.consumed.set()
         await self.block.wait()
 
     async def aclose(self) -> None:
@@ -1229,9 +1638,14 @@ def test_closing_generation_closes_incomplete_upstream_response() -> None:
             transport=httpx.MockTransport(lambda _request: httpx.Response(200, stream=stream))
         )
         iterator = adapter.generate("prompt", max_new_tokens=4)
-        first = await anext(iterator)
-        assert first.text_delta == "x"
+        consume = asyncio.ensure_future(anext(iterator))
+        await asyncio.wait_for(stream.consumed.wait(), timeout=2)
+        assert not consume.done()
+        consume.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consume
         await iterator.aclose()
+        assert adapter._active_generations == 0
         await adapter.aclose_client()
         return stream.closed
 
@@ -1247,8 +1661,9 @@ def test_generation_drain_blocks_new_admission_and_waits_for_active_stream() -> 
         parameters = {"prompt": "prompt", "max_new_tokens": 4}
         preflight_result = adapter.preflight_generate(parameters, stream=True)
         iterator = adapter.generate_with_preflight(parameters, preflight_result)
-        first = await anext(iterator)
-        assert first.text_delta == "x"
+        consume = asyncio.ensure_future(anext(iterator))
+        await asyncio.wait_for(stream.consumed.wait(), timeout=2)
+        assert not consume.done()
 
         drain = asyncio.create_task(adapter.drain_generation())
         await asyncio.sleep(0)
@@ -1256,11 +1671,46 @@ def test_generation_drain_blocks_new_admission_and_waits_for_active_stream() -> 
         with pytest.raises(GenerationDrainingError):
             adapter.preflight_generate(parameters, stream=True)
 
+        consume.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consume
         await iterator.aclose()
-        await drain
+        await asyncio.wait_for(drain, timeout=2)
         return stream.closed, client.is_closed, adapter._active_generations
 
     assert asyncio.run(scenario()) == (True, True, 0)
+
+
+def test_timeout_before_visible_output_closes_response_and_releases_generation() -> None:
+    async def scenario() -> None:
+        error = httpx.ReadTimeout("child read timed out")
+
+        class TimeoutStream(httpx.AsyncByteStream):
+            closed = False
+
+            async def __aiter__(self) -> AsyncIterator[bytes]:
+                yield _sse(_choice([13])).removesuffix(b"data: [DONE]\n\n")
+                raise error
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        adapter = _adapter()
+        stream = TimeoutStream()
+        adapter._http_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _request: httpx.Response(200, stream=stream))
+        )
+        emitted: list[Any] = []
+        with pytest.raises(httpx.ReadTimeout) as exc_info:
+            async for chunk in adapter.generate("prompt", max_new_tokens=4):
+                emitted.append(chunk)
+        assert exc_info.value is error
+        assert emitted == []
+        assert stream.closed
+        assert adapter._active_generations == 0
+        await asyncio.wait_for(adapter.drain_generation(), timeout=2)
+
+    asyncio.run(scenario())
 
 
 class _BlockingCloseFailureCompletion:
@@ -1367,18 +1817,21 @@ def test_independent_requests_share_client_and_reach_transport_concurrently() ->
         adapter = _adapter()
         active = 0
         peak = 0
+        both_started = asyncio.Event()
 
         async def handler(_request: httpx.Request) -> httpx.Response:
             nonlocal active, peak
             active += 1
             peak = max(peak, active)
-            await asyncio.sleep(0.01)
+            if active == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=2)
             active -= 1
             return httpx.Response(
                 200,
                 content=_sse(
-                    {"choices": [{"index": 0, "text": "x", "finish_reason": "stop"}]},
-                    {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+                    _choice([13], finish_reason="stop"),
+                    _usage(1),
                 ),
             )
 


### PR DESCRIPTION
## Summary

- Preserve generated spacing and punctuation by decoding TensorRT-LLM token IDs as one complete sequence with the model's tokenizer.
- Remove matched stop sequences from the returned text, token usage, and log probabilities, including stops split across response events.
- Reject malformed or incomplete completion streams while preserving cancellation, drain, and timeout cleanup.

This adapter emits text after the complete response is verified, including with `stream=True`. The README documents the resulting delay before the first visible text. Other generation adapters are unchanged.

## Validation

- Confirmed 12 regression failures before the fix, then verified they pass.
- Combined TensorRT, shared generation, streaming, drain, and cleanup tests: 440 passed, 1 Linux-only skip on macOS.
- Ruff lint/format checks, focused production typecheck, and public-reference checks passed.
- Deterministic tests cover context-sensitive decoding, stop handling, usage/logprob alignment, malformed streams, cancellation, and timeouts.

No GPU inference or model download was performed. No dependency, model-profile, or release-workflow changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TensorRT-LLM streaming completions with more consistent text output and stop-sequence handling.
  * Added reliable usage and logprob reporting, including correct removal of stop-token content.
  * Improved first-token delivery and timeout behavior during generation.
  * Added stronger validation for streamed completion results and terminal responses.

* **Documentation**
  * Documented TensorRT-LLM completion behavior, including streaming, stop sequences, usage, logprobs, and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->