### PR TITLE
fix(helm): make KEDA hook Job resources configurable

### DIFF
--- a/deploy/helm/sie-cluster/README.md
+++ b/deploy/helm/sie-cluster/README.md
@@ -385,6 +385,20 @@ Kubernetes operation/hook; it exceeds the longest default 15-minute Job. With
 a custom `pollingInterval` above 30 seconds, also make the timeout exceed the
 KEDA health deadline of `3 * pollingInterval + 240` seconds.
 
+Size `keda-apply`, `keda-cleanup`, and the KEDA ScaledObject/HPA gate with
+`hooks.resources`. The default memory limit is 1Gi. Requests stay at 128Mi.
+
+```yaml
+hooks:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "1Gi"
+```
+
 ### Scale-from-Zero Trigger
 
 The gateway emits `sie.gateway.pending_demand` over OTLP when requests arrive

--- a/deploy/helm/sie-cluster/templates/_helpers.tpl
+++ b/deploy/helm/sie-cluster/templates/_helpers.tpl
@@ -627,6 +627,10 @@ Args (dict): base, suffix.
 alpine/k8s:1.29.10@sha256:a1f03afdc59b1acde5e740ed855079c7361505d6fed9d9c6069c8c3307264348
 {{- end }}
 
+{{- define "sie-cluster.hooks.resources" -}}
+{{- toYaml .Values.hooks.resources -}}
+{{- end }}
+
 {{/* Explicit kubectl credentials for hook containers. */}}
 {{- define "sie-cluster.kubernetes.inClusterKubeconfig" -}}
 KUBE_SERVICE_ACCOUNT_DIR=/var/run/secrets/kubernetes.io/serviceaccount

--- a/deploy/helm/sie-cluster/templates/hooks/keda-ready-test.yaml
+++ b/deploy/helm/sie-cluster/templates/hooks/keda-ready-test.yaml
@@ -383,12 +383,7 @@ spec:
               echo "FAILED: ScaledObjects and controller-reconciled HPAs did not become current, Ready, and trigger-healthy after a complete KEDA failure window"
               exit 1
           resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 256Mi
+            {{- include "sie-cluster.hooks.resources" . | nindent 12 }}
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists

--- a/deploy/helm/sie-cluster/templates/keda-lifecycle.yaml
+++ b/deploy/helm/sie-cluster/templates/keda-lifecycle.yaml
@@ -118,9 +118,4 @@ spec:
               done
               echo "Release-owned KEDA ScaledObjects removed"
           resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
+            {{- include "sie-cluster.hooks.resources" . | nindent 12 }}

--- a/deploy/helm/sie-cluster/templates/keda-scaledobject.yaml
+++ b/deploy/helm/sie-cluster/templates/keda-scaledobject.yaml
@@ -479,12 +479,7 @@ spec:
               fi
               echo "SUCCESS: ScaledObjects applied and obsolete release objects pruned"
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 200m
-              memory: 256Mi
+            {{- include "sie-cluster.hooks.resources" . | nindent 12 }}
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists

--- a/deploy/helm/sie-cluster/values.yaml
+++ b/deploy/helm/sie-cluster/values.yaml
@@ -1262,6 +1262,17 @@ healthGates:
   # This cannot disable the mandatory autoscaling control-path gates.
   enabled: false
 
+# -- Resource requests/limits for kubectl-based KEDA hook Jobs
+# (keda-apply, keda-cleanup, and the KEDA ScaledObject/HPA gate).
+hooks:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "1Gi"
+
 # -- HuggingFace token secret (optional)
 # Create via Helm instead of kubectl for fully declarative deploys.
 # Pass token at install time: --set hfToken.create=true --set hfToken.value=<token>


### PR DESCRIPTION
## Summary
The keda-apply hook is OOMKilled at a hardcoded 256Mi on upgrade. Install skips the ownership jq path, so the same limit passes there. The chart had no values key for that Job, and Helm post-renderers do not patch hook manifests.

I added `hooks.resources` and wired it through keda-apply, keda-cleanup, and the KEDA ScaledObject/HPA gate. Default memory limit is 1Gi. Requests stay at 128Mi so scheduling does not get tighter. backoffLimit stays 0. A retry in the same memory limit does not fix this.

Closes #248

## Compatibility
New values key with a chart default. Existing overlays keep working. The rendered hook memory limit changes from 256Mi to 1Gi. Clusters with a tighter LimitRange can set `hooks.resources.limits.memory` down.

Did not bump Chart.yaml. Release automation owns the version.

## Test plan
- [x] `helm lint --set payloadStore.enabled=false`
- [x] `helm template` with default values and each of `values-aws.yaml`, `values-gke.yaml`, `values-aks.yaml`, `values-ack.yaml`
- [x] `helm template` with `autoscaling.enabled=true` shows 128Mi request and 1Gi limit on the three Jobs
- [x] `--set hooks.resources.limits.memory=2Gi` changes those Job limits only
- [x] `helm package` succeeds and `Chart.lock` is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable CPU and memory requests and limits for KEDA hook Jobs.
  - Applied shared resource settings to KEDA apply, cleanup, and readiness checks.
  - Added default resource values, including 128Mi memory requests and 1Gi memory limits.

- **Documentation**
  - Documented how to size KEDA hook Jobs and customize their resources.
  - Added an example configuration for overriding the defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->